### PR TITLE
Add public documentation

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -34,6 +34,6 @@ resource "stackpath_compute_workload" "my-compute-workload" {
 
 The following arguments are supported in the `provider` block:
 
-* `stack` - (Optional) This is the ID of stack that all new services are provisioned to. Stacks are folder-like organizational units on the StackPath platform and are typically used to organize services by project or user. Stack IDs are UUID v4 formatted strings. 
-* `client_id` - (Optional) This is the API client ID of the StackPath user that will interact with Terraform. All services provisioned at StackPath through Terraform belong to their creating user.
-* `client_secret` - (Optional) This is the API client secret of the StackPath user that will interact with Terraform. Client secrets should be stored securely and not exposed to the public.
+* `stack` - (Required) This is the ID of stack that all new services are provisioned to. Stacks are folder-like organizational units on the StackPath platform and are typically used to organize services by project or user. Stack IDs are UUID v4 formatted strings. `stack` can be defined in either the provider definition or the `STACKPATH_STACK` environment variable.
+* `client_id` - (Required) This is the API client ID of the StackPath user that will interact with Terraform. All services provisioned at StackPath through Terraform belong to their creating user. `client_id` can be defined in either the provider definition or the `STACKPATH_CLIENT_ID` environment variable.
+* `client_secret` - (Required) This is the API client secret of the StackPath user that will interact with Terraform. Client secrets should be stored securely and not exposed to the public. `client_secret` can be defined in either the provider definition or the `STACKPATH_CLIENT_SECRET` environment variable.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -1,0 +1,39 @@
+---
+layout: "stackpath"
+page_title: "Provider: StackPath"
+sidebar_current: "docs-stackpath-index"
+description: |-
+  The StackPath provider is used to interact with resources on the StackPath edge platform.
+---
+
+# StackPath Provider
+
+The StackPath provider is used to interact with resources on the StackPath edge platform.
+
+The provider allows you manage your resources on the StackPath edge and integrate them with other Terraform-supported providers. It needs to be configured with the proper credentials before it can be used.
+
+Use the navigation to the left to read about the available resources.
+
+## Example Usage
+
+```hcl
+# Configure the StackPath Provider
+provider "stackpath" {
+  stack         = "${var.stackpath_stack}"
+  client_id     = "${var.stackpath_client_id}"
+  client_secret = "${var.stackpath_client_secret}"
+}
+
+# Create a new Edge Compute workload
+resource "stackpath_compute_workload" "my-compute-workload" {
+  # ...
+}
+```
+
+## Argument Reference
+
+The following arguments are supported in the `provider` block:
+
+* `stack` - (Optional) This is the ID of stack that all new services are provisioned to. Stacks are folder-like organizational units on the StackPath platform and are typically used to organize services by project or user. Stack IDs are UUID v4 formatted strings. 
+* `client_id` - (Optional) This is the API client ID of the StackPath user that will interact with Terraform. All services provisioned at StackPath through Terraform belong to their creating user.
+* `client_secret` - (Optional) This is the API client secret of the StackPath user that will interact with Terraform. Client secrets should be stored securely and not exposed to the public.

--- a/website/docs/r/compute_network_policy.html.markdown
+++ b/website/docs/r/compute_network_policy.html.markdown
@@ -54,7 +54,7 @@ resource "stackpath_compute_network_policy" "web-server" {
 * `instance_selector` - (Optional) A compute workload instance that the network policy applies to. A network policy with no selectors applies to all networks and all instances in the stack. See [Selectors](#selectors) below for details.
 * `network_selector` - (Optional) A network that the network policy applies to. A network policy with no selectors applies to all networks and all instances in the stack. See [Selectors](#selectors) below for details.
 * `policy_types` - (Required) A list of network policy types, either "INGRESS" and/or "EGRESS". 
-* `priority` - (Required) A priority value between 1 and 65000. Higher priority network policies override lower priority policies.
+* `priority` - (Required) A priority value between 1 and 65000. Higher priority network policies override lower priority policies, and priorities must be unique across the stack.
 * `egress` - (Optional) Outbound networking information. See [Egress](#egress) below for details.
 * `ingress` - (Optional) Inbound networking information. See [Ingress](#ingress) below for details.
 
@@ -116,7 +116,7 @@ resource "stackpath_compute_network_policy" "web-server" {
 
 * `key` - (Required) The name of the data that a selector is based on.
 * `operator` - (Required) A logical operator to apply to a selector like "=", "!=", "in", or "notin".
-* `values` - (Required) Data values to look for in the selector.
+* `values` - (Required) Data values to look for in a label selector.
 
 ## Import
 

--- a/website/docs/r/compute_network_policy.html.markdown
+++ b/website/docs/r/compute_network_policy.html.markdown
@@ -1,0 +1,127 @@
+---
+layout: "stackpath"
+page_title: "StackPath: stackpath_compute_network_policy"
+sidebar_current: "docs-stackpath-resource-compute-network-policy"
+description: |-
+  Network ingress and egress control of StackPath computing workloads.
+---
+
+# stackpath\_compute\_network\_policy
+
+Network ingress and egress control of StackPath computing workloads.
+
+## Example Usage
+
+```hcl
+resource "stackpath_compute_network_policy" "web-server" {
+  name        = "Allow HTTP traffic to web servers"
+  slug        = "web-servers-allow-http"
+  description = "A network policy that allows HTTP access to instances with the web server role"
+  priority    = 20000
+
+  instance_selector {
+    key      = "role"
+    operator = "in"
+    values   = ["web-server"]
+  }
+
+  policy_types = ["INGRESS"]
+
+  ingress {
+    action      = "ALLOW"
+    description = "Allow port 80 traffic from all IPs"
+    protocol {
+      tcp {
+        destination_ports = [80]
+      }
+    }
+    from {
+      ip_block {
+        cidr = "0.0.0.0/0"
+      }
+    }
+  }
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) A human readable name.
+* `slug` - (Required) A programmatic name for the network policy.
+* `description` - (Optional) A brief description.
+* `labels` - (Optional) Key/value pairs of arbitrary label names and values that can be referenced as selectors. 
+* `annotations` - (Optional) Key/value pairs that define StackPath-specific network policy configuration.
+* `instance_selector` - (Optional) A compute workload instance that the network policy applies to. A network policy with no selectors applies to all networks and all instances in the stack. See [Selectors](#selectors) below for details.
+* `network_selector` - (Optional) A network that the network policy applies to. A network policy with no selectors applies to all networks and all instances in the stack. See [Selectors](#selectors) below for details.
+* `policy_types` - (Required) A list of network policy types, either "INGRESS" and/or "EGRESS". 
+* `priority` - (Required) A priority value between 1 and 65000. Higher priority network policies override lower priority policies.
+* `egress` - (Optional) Outbound networking information. See [Egress](#egress) below for details.
+* `ingress` - (Optional) Inbound networking information. See [Ingress](#ingress) below for details.
+
+### Egress
+
+`egress` takes the following arguments:
+
+* `action` - (Required) How a network policy treats outbound traffic, either "ALLOW" or "BLOCK".
+* `description` - (Optional) A brief description.
+* `protocol` - (Optional) Network protocol specific information. See [Network Protocols](#network-protocols) below for details.
+* `to` - (Optional) Allow or block outbound traffic to the specified targets. See [Network Selectors](#network-selectors) below for details.
+
+### Ingress
+
+`ingress` takes the following arguments:
+
+* `action` - (Required) How a network policy treats outbound traffic, either "ALLOW" or "BLOCK".
+* `description` - (Optional) A brief description.
+* `protocol` - (Optional) Network protocol specific information. See [Network Protocols](#network-protocols) below for details.
+* `from` - (Optional) Allow or block inbound traffic from the specified targets. See [Network Selectors](#network-selectors) below for details.
+
+### Network Protocols
+
+`protocol` takes the following arguments:
+
+* `ah` - (Optional) Allow or block the IPSec Authentication Header protocol. This argument block has no configuration.
+* `esp` - (Optional) Allow or block the IPSec Encapsulating Security Payload protocol. This argument block has no configuration.
+* `gre` - (Optional) Allow or block the Generic Routing Encapsulation protocol. This argument block has no configuration.
+* `icmp` - (Optional) Allow or block the Internet Control Message Protocol. This argument block has no configuration.
+* `tcp` - (Optional) Allow or block Transmission Control Protocol connections. See [Network Ports](#network-ports) below for details.
+* `udp` - (Optional) Allow or block User Datagram Protocol connections. See [Network Ports](#network-ports) below for details.
+* `tcp_udp` - (Optional) Allow or block both TCP and UDP connections. See [Network Ports](#network-ports) below for details.
+
+### Network Ports
+
+`tcp`, `udp`, and `tcp_udp` take the following arguments:
+
+* `source_ports` - (Optional) A list of destination ports.
+* `destination_ports` - (Optional) A list of destination ports.
+
+### Network Selectors
+
+`to` and `from` take the following arguments:
+
+* `instance_selector` - (Optional) Target the given compute workload instances. See [Selectors](#selectors) below for details.
+* `network_selector` - (Optional) Target the given networks. See [Selectors](#selectors) below for details.
+* `ip_block` - (Optional) Target the given IP address blocks. See [IP Blocks](#ip-blocks) below for details. 
+
+#### IP Blocks
+
+`ip_block` takes the following arguments:
+
+* `cidr` - (Required) A CIDR formatted subnet.
+* `except` - (Optional) A list of CIDR formatted subnets to exclude from the `cidr` subnet.
+
+### Selectors
+
+`instance_selector` and `network_selector` take the following arguments:
+
+* `key` - (Required) The name of the data that a selector is based on.
+* `operator` - (Required) A logical operator to apply to a selector like "=", "!=", "in", or "notin".
+* `values` - (Required) Data values to look for in the selector.
+
+## Import
+
+StackPath compute network policies can be imported by their UUID v4 formatted id. e.g.
+
+```
+$ terraform import stackpath_compute_network_policy.terraform bdb77768-2938-4ad8-a736-be5290add801
+```

--- a/website/docs/r/compute_workload.html.markdown
+++ b/website/docs/r/compute_workload.html.markdown
@@ -91,7 +91,7 @@ resource "stackpath_compute_workload" "my-compute-workload" {
 
 `network_interfaces` supports the following arguments:
 
-* `network` - (Required) A name that can be that can be referenced a [selector](#selectors) by [network policies](/docs/providers/stackpath/r/compute_network_policy.html).
+* `network` - (Required) A name that can be that can be referenced by a [selector](#selectors) by [network policies](/docs/providers/stackpath/r/compute_network_policy.html). Currently, only the value "default" is supported.
 
 ### Image Pull Credentials
 

--- a/website/docs/r/compute_workload.html.markdown
+++ b/website/docs/r/compute_workload.html.markdown
@@ -77,14 +77,14 @@ resource "stackpath_compute_workload" "my-compute-workload" {
 ## Argument Reference
 
 * `name` - (Required) A human readable name.
-* `slug` - (Required) A programmatic name for the workload. Workload slugs are used to build the workload's instance names.
+* `slug` - (Required) A programmatic name for the workload. Workload slugs are used to build the workload's instance names and cannot be changed after creation.
 * `labels` - (Optional) Key/value pairs of arbitrary label names and values that can be referenced as [selectors](#selectors) by [network policies](/docs/providers/stackpath/r/compute_network_policy.html). 
 * `annotations` - (Optional) Key/value pairs that define StackPath-specific workload configuration.
 * `network_interface` - (Required) Networks to place the compute instance on. See [Network Interfaces](#network-interfaces) below for details.
-* `image_pull_credentials` - (Optional) Credentials to pull virtual machine and container images with. See [Image Pull Credentials](#image-pull-credentials) below for details.
-* `virtual_machine` - (Optional) Virtual machine configuration. At least one of `virtual_machine` or `container` must be provided. See [Virtual Machines](#virtual-machines) below for details.
+* `image_pull_credentials` - (Optional) Credentials to pull container images with. See [Image Pull Credentials](#image-pull-credentials) below for details.
+* `virtual_machine` - (Optional) Virtual machine configuration. StackPath supports a single virtual machine specification in a workload. At least one of `virtual_machine` or `container` must be provided. See [Virtual Machines](#virtual-machines) below for details.
 * `container` - (Optional) Container configuration. At least one of `virtual_machine` or `container` must be provided. See [Containers](#containers) below for details.
-* `volume_claim` - (Optional) Storage that can be mounted and shared amongst a compute workload's instances. See [Volume Claims](#volume-claims) below for details.
+* `volume_claim` - (Optional) Storage that is mounted to a compute workload's instances. See [Volume Claims](#volume-claims) below for details.
 * `target` - (Required) How the compute workload should be deployed across the StackPath edge platform. See [Deployment Targets](#deployment-targets) below for details.
 
 ### Network Interfaces
@@ -141,7 +141,7 @@ resource "stackpath_compute_workload" "my-compute-workload" {
 
 * `key` - (Required) The environment variable name.
 * `value` - (Optional) The environment variable value. One of `value` or `secret_value` must be provided.
-* `secret_value` - (Optional) A sensitive environment variable value. One of `value` or `secret_value` must be provided.
+* `secret_value` - (Optional) A sensitive environment variable value. This value cannot be read after it is set. One of `value` or `secret_value` must be provided.
 
 ### Network Ports
 
@@ -184,7 +184,7 @@ resource "stackpath_compute_workload" "my-compute-workload" {
 
 `tcp_socket` takes the following arguments:
 
-`port` - (Required) The TCP port number to connect to. 
+* `port` - (Required) The TCP port number to connect to. 
 
 ### Resources
 
@@ -220,7 +220,7 @@ resource "stackpath_compute_workload" "my-compute-workload" {
 
 `metrics` takes the following arguments:
 
-* `metric` - (Required) A hardware metric to use as a scaling basis.
+* `metric` - (Required) A hardware metric to use as a scaling basis. Currently, only the "cpu" metric is supported.
 * `average_utilization` - (Optional) The `metric`'s average utilization that should trigger scaling. One of `average_utilization` or `average_value` must be provided.
 * `average_value` - (Optional) The `metric`'s average value that should trigger scaling. One of `average_utilization` or `average_value` must be provided.
 
@@ -230,11 +230,11 @@ resource "stackpath_compute_workload" "my-compute-workload" {
 
 * `key` - (Required) The name of the data that a selector is based on.
 * `operator` - (Required) A logical operator to apply to a selector like "=", "!=", "in", or "notin".
-* `values` - (Required) Data values to look for in the selector.
+* `values` - (Required) Data values to look for in a label selector.
 
 ## Instances
 
-Instances are the individual container or virtual machines running in a StackPath Edge Compute workload. Instances are accessed via a `stackpath_resource_compute_workload`'s computed `instances` field.
+A workload instance is a collection of containers or a virtual machine created based on the template provided in a workload. Instances are accessed via a `stackpath_resource_compute_workload`'s computed `instances` field.
 
 ### Example Usage
 
@@ -255,7 +255,7 @@ output "my-compute-workload-instances" {
 ### Instance Fields
 
 * `name` - (Required) An instance's name. Names are generated from their corresponding workload's slug, followed by a unique hash.
-* `metadata` - (Optional) Metadata associated with a running instance, including the workload's `labels` and [annotations](#annotations), both supplied by the user and geneerted by StackPath. 
+* `metadata` - (Optional) Metadata associated with a running instance, including the workload's `labels` and [annotations](#annotations), both supplied by the user and generated by StackPath. 
 * `location` - (Optional) The instance's physical location. See [Locations](#locations) below for details.
 * `external_ip_address` - (Optional) An IP address bound to the instance.
 * `ip_address` - (Optional) An instance's internal IP address.

--- a/website/docs/r/compute_workload.html.markdown
+++ b/website/docs/r/compute_workload.html.markdown
@@ -1,0 +1,302 @@
+---
+layout: "stackpath"
+page_title: "StackPath: stackpath_compute_workload"
+sidebar_current: "docs-stackpath-resource-compute-workload"
+description: |-
+  A computing application deployed to StackPath's edge network.
+---
+
+# stackpath\_compute\_workload
+
+A computing application deployed to StackPath's edge network.
+
+## Example Usage
+
+```hcl
+resource "stackpath_compute_workload" "my-compute-workload" {
+  name = "my-compute-workload"
+  slug = "my-compute-workload"
+
+  annotations = {
+    # request an anycast IP
+    "anycast.platform.stackpath.net" = "true"
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  container {
+    # Name that should be given to the container
+    name = "app"
+    
+    # Nginx image to use for the container
+    image = "nginx:latest"
+    
+    # Override the command that's used to execute the container. If this option 
+    # is not provided the default entrypoint and command defined by the docker 
+    # image will be used.
+    # command = []
+    resources {
+      requests = {
+        "cpu"    = "1"
+        "memory" = "2Gi"
+      }
+    }
+
+    env {
+      key   = "VARIABLE_NAME"
+      value = "VALUE"
+    }
+  }
+
+  target {
+    name         = "us"
+    min_replicas = 1
+    max_replicas = 2
+    scale_settings {
+      metrics {
+        metric = "cpu"
+        # Scale up when CPU averages 50%.
+        average_utilization = 50
+      }
+    }
+    # Deploy these 1 to 2 instances in Dallas, TX, USA and Amsterdam, NL.
+    deployment_scope = "cityCode"
+    selector {
+      key      = "cityCode"
+      operator = "in"
+      values   = [
+        "DFW", "AMS"
+      ]
+    }
+  }
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) A human readable name.
+* `slug` - (Required) A programmatic name for the workload. Workload slugs are used to build the workload's instance names.
+* `labels` - (Optional) Key/value pairs of arbitrary label names and values that can be referenced as [selectors](#selectors) by [network policies](/docs/providers/stackpath/r/compute_network_policy.html). 
+* `annotations` - (Optional) Key/value pairs that define StackPath-specific workload configuration.
+* `network_interface` - (Required) Networks to place the compute instance on. See [Network Interfaces](#network-interfaces) below for details.
+* `image_pull_credentials` - (Optional) Credentials to pull virtual machine and container images with. See [Image Pull Credentials](#image-pull-credentials) below for details.
+* `virtual_machine` - (Optional) Virtual machine configuration. At least one of `virtual_machine` or `container` must be provided. See [Virtual Machines](#virtual-machines) below for details.
+* `container` - (Optional) Container configuration. At least one of `virtual_machine` or `container` must be provided. See [Containers](#containers) below for details.
+* `volume_claim` - (Optional) Storage that can be mounted and shared amongst a compute workload's instances. See [Volume Claims](#volume-claims) below for details.
+* `target` - (Required) How the compute workload should be deployed across the StackPath edge platform. See [Deployment Targets](#deployment-targets) below for details.
+
+### Network Interfaces
+
+`network_interfaces` supports the following arguments:
+
+* `network` - (Required) A name that can be that can be referenced a [selector](#selectors) by [network policies](/docs/providers/stackpath/r/compute_network_policy.html).
+
+### Image Pull Credentials
+
+`image_pull_credentials` supports the following arguments:
+
+* `docker_registry` - (Required) Authentication configuration needed to pull images from a Docker registry. See [Docker Registry Credentials](#docker-registry-credentials) below for details.
+
+#### Docker Registry Credentials
+
+`docker_registry` supports the following arguments:
+
+* `server` - (Optional) The address of a Docker registry server. Defaults to "hub.docker.com".
+* `username` - (Required) A username to connect the Docker registry.
+* `password` - (Required) A password to connect to the Docker registry.
+* `email` - (Optional) An email address to use with the Docker registry account.
+
+### Virtual Machines
+
+`virtual_machine` supports the following arguments:
+
+* `name` - (Required) A virtual machine's name.
+* `image` - (Required) The location of a Docker image to run as a virtual machine.
+* `port` - (Optional) Network ports to expose from the virtual machine. See [Network Ports](#network-ports) below for details.
+* `liveness_probe` - (Optional) Criteria to determine if the compute workload is online. See [Probes](#probes) below for details.
+* `readiness_probe` - (Optional) Criteria to determine if the compute workload is ready to serve requests. See [Probes](#probes) below for details.
+* `resources` - (Required) Hardware resources required by the virtual machine. See [Resources](#resources) below for details.
+* `volume_mount` - (Optional) Storage volumes to mount in the virtual machine. See [Volume Mounts](#volume-mounts) below for details.
+* `user_data` - (Optional) Base64-encoded [cloud-init](https://cloud-init.io/) user data.
+
+### Containers
+
+`container` supports the following arguments:
+
+* `name` - (Required) A container's name.
+* `image` - (Required) A container's image location.
+* `command` - (Optional) The command to execute a container.
+* `env` - (Optional) Environment variables to set in the container instance. See [Environment Variables](#environment-variables) below for details. 
+* `port` - (Optional) Networking ports to expose from the container. See [Network Ports](#network-ports) below for details.
+* `liveness_probe` - (Optional) Criteria to determine if the compute workload is online. See [Probes](#probes) below for details.
+* `readiness_probe` - (Optional) Criteria to determine if the compute workload is ready to serve requests. See [Probes](#probes) below for details.
+* `resources` - (Required) Hardware resources required by the container. See [Resources](#resources) below for details.
+* `volume_mount` - (Optional) Storage volumes to mount in the container. See [Volume Mounts](#volume-mounts) below for details.
+
+#### Environment Variables
+
+`env` supports the following arguments:
+
+* `key` - (Required) The environment variable name.
+* `value` - (Optional) The environment variable value. One of `value` or `secret_value` must be provided.
+* `secret_value` - (Optional) A sensitive environment variable value. One of `value` or `secret_value` must be provided.
+
+### Network Ports
+
+`port` supports the following arguments:
+
+* `name` - (Required) The network port's name.
+* `port` - (Required) The network port's number.
+* `protocol` - (Optional) The network port's protocol, either "tcp" or "udp". Defaults to "tcp".
+
+### Volume Claims
+
+`volume_claim` supports the following arguments:
+
+* `name` - (Required) A human readable name.
+* `slug` - (Optional) A programmatic slug. Reference this slug when [mounting](#volume-mounts) the claim into a workload's instances.
+* `resources` - (Required) Hardware resources to allocate to the volume claim. See [Resources](#resources) below for details.
+
+### Probes
+
+`liveness_probe` and `readiness_probe` take the following arguments:
+
+* `http_get` - (Optional) HTTP request information. One of `http_get` or `tcp_socket` must be provided. See [HTTP probes](#http-probes) below for details
+* `tcp_socket` - (Optional) TCP socket information. One of `http_get` or `tcp_socket` must be provided. See [TCP probes](#tcp-probes) below for details
+* `initial_delay_seconds` - (Optional) The initial delay before the probe starts. Defaults to 0.
+* `timeout_seconds` - (Optional) The number of seconds before the probe times out and is considered a failure. Defaults to 10.
+* `period` - (Optional) The frequency of the probe. Defaults to 60.
+* `success_threshold` - (Required) The minimum consecutive successes required before a probe is considered successful after a failure. This must be 1 for liveness probes.
+* `failure_threshold` - (Required) The amount of failures seen before the probe is considered a failure.
+
+#### HTTP Probes
+
+`http_get` takes the following arguments:
+
+* `path` - (Optional) The URL path to request from the application. Defaults to "/".
+* `port` - (Required) The TCP port the HTTP service listens on.
+* `scheme` - (Optional) The URL scheme to query the application with. Defaults to "http".
+* `http_headers` - (Optional) HTTP header names and values to send to the HTTP service. 
+
+#### TCP probes
+
+`tcp_socket` takes the following arguments:
+
+`port` - (Required) The TCP port number to connect to. 
+
+### Resources
+
+`resources` takes the following arguments:
+
+* `requests` - (Required) Key/value pairs of hardware resource types and values.
+
+### Volume Mounts
+
+`volume-mount` takes the following arguments:
+
+* `slug` - (Required) The slug of the [volume claim](#volume-claim) to mount into the workload's instances.
+* `mount_path` - (Required) The path the volume is mounted to in a workload's instances.
+
+### Deployment Targets
+
+`target` takes the following arguments: 
+
+* `name` - (Required) A human readable name.
+* `min_replicas` - (Required) The minimum number of instances that should be deployed to a target.
+* `max_replicas` - (Optional) The maximum number of instances that should be deployed to a target.
+* `scale_settings` - (Optional) How to auto-scale the number of instances in the deployment target. See [Scaling Settings](#scaling-settings) below for details.
+* `deployment_scope` - (Optional) Criteria that defines a deployment target. Defaults to "cityCode".
+* `selector` - (Required) The value of the deployment scope to deploy to. See [Selectors](#selectors) below for details.
+
+#### Scaling Settings
+
+`scale_settings` takes the following arguments:
+
+* `metrics` - (Required) Scaling metrics. See [Scaling Metrics](#scaling-metrics) below for details.
+
+##### Scaling Metrics 
+
+`metrics` takes the following arguments:
+
+* `metric` - (Required) A hardware metric to use as a scaling basis.
+* `average_utilization` - (Optional) The `metric`'s average utilization that should trigger scaling. One of `average_utilization` or `average_value` must be provided.
+* `average_value` - (Optional) The `metric`'s average value that should trigger scaling. One of `average_utilization` or `average_value` must be provided.
+
+#### Selectors
+
+`selector` takes the following arguments:
+
+* `key` - (Required) The name of the data that a selector is based on.
+* `operator` - (Required) A logical operator to apply to a selector like "=", "!=", "in", or "notin".
+* `values` - (Required) Data values to look for in the selector.
+
+## Instances
+
+Instances are the individual container or virtual machines running in a StackPath Edge Compute workload. Instances are accessed via a `stackpath_resource_compute_workload`'s computed `instances` field.
+
+### Example Usage
+
+```hcl
+# Output a StackPath compute workload's instances' name, internal IP addresses, 
+# and status
+output "my-compute-workload-instances" {
+  value = {
+    for instance in stackpath_compute_workload.my-compute-workload.instances :
+    instance.name => {
+      "ip_address" = instance.external_ip_address
+      "phase"      = instance.phase
+    }
+  }
+}
+```
+
+### Instance Fields
+
+* `name` - (Required) An instance's name. Names are generated from their corresponding workload's slug, followed by a unique hash.
+* `metadata` - (Optional) Metadata associated with a running instance, including the workload's `labels` and [annotations](#annotations), both supplied by the user and geneerted by StackPath. 
+* `location` - (Optional) The instance's physical location. See [Locations](#locations) below for details.
+* `external_ip_address` - (Optional) An IP address bound to the instance.
+* `ip_address` - (Optional) An instance's internal IP address.
+* `network_interface` - (Optional) A network interface bound to an instance. See [Instance Network Interfaces](#instance-network-interfaces) below for details.
+* `virtual_machine` - (Optional) An instance's [virtual machine](#virtual-machines) specification. An instance has either a `virtual_machine` or `container`.
+* `container` - (Optional) An instance's [container](#containers) specification. An instance has either a `virtual_machine` or `container`.
+* `phase` - (Optional) An instance's current status, such as "STARTING", "RUNNING", "FAILED", or "STOPPED".
+* `reason` - (Optional) A short reason why an instance is in its current phase.
+* `message` - (Optional) A longer message with details why an instance is in its current phase.
+
+### Locations
+
+`locaton` has the following fields:
+
+* `name` - (Optional) A location's name.
+* `city`- (Optional) A location's city.
+* `city_code` - (Optional) A city's [IATA code](https://en.wikipedia.org/wiki/IATA_airport_code).
+* `subdivision` - (Optional) A location's subdivision.
+* `subdivision_code` - (Optional) A subdivision's [ISO 3166-2](https://en.wikipedia.org/wiki/ISO_3166-2) code.
+* `country` - (Optional) A location's country.
+* `country_code` - (Optional) A country's [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) code.
+* `region` - (Optional) A location's region.
+* `region_code` - (Optional) A region's GeoIP code.
+* `continent` - (Optional) A location's continent.
+* `continent_code` - (Optional) A continent's GeoIP code.
+* `latitude` - (Optional) A location's latitude coordinate.
+* `longitude` - (Optional) A location's longitude coordinate.
+
+### Instance Network Interfaces
+
+`network_interface` has the following fields:
+
+* `network` - (Required) The name of the [workload network interface](#network-interfaces).
+* `ip_address` - (Required) A network interface's primary IP address.
+* `ip_address_aliases` - (Optional) Additional IP addresses bound to a network interface.
+* `gateway` - (Required) A network interface subnet's gateway IP address.
+
+## Import
+
+StackPath compute workloads can be imported by their UUID v4 formatted id. e.g.
+
+```
+$ terraform import stackpath_compute_workload.terraform bdb77768-2938-4ad8-a736-be5290add801
+```

--- a/website/stackpath.erb
+++ b/website/stackpath.erb
@@ -1,0 +1,29 @@
+<% wrap_layout :inner do %>
+  <% content_for :sidebar do %>
+    <div class="docs-sidebar hidden-print affix-top" role="complementary">
+      <ul class="nav docs-sidenav">
+        <li<%= sidebar_current("docs-home") %>>
+          <a href="/docs/providers/index.html">All Providers</a>
+        </li>
+
+        <li<%= sidebar_current("docs-stackpath-index") %>>
+          <a href="/docs/providers/stackpath/index.html">StackPath Provider</a>
+        </li>
+
+        <li<%= sidebar_current("docs-stackpath-resource") %>>
+          <a href="#">Resources</a>
+          <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-stackpath-resource-compute-workload") %>>
+              <a href="/docs/providers/stackpath/r/compute_workload.html">stackpath_compute_workload</a>
+            </li>
+            <li<%= sidebar_current("docs-stackpath-resource-compute-network-policy") %>>
+              <a href="/docs/providers/stackpath/r/compute_network_policy.html">stackpath_compute_network_policy</a>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </div>
+  <% end %>
+
+  <%= yield %>
+  <% end %>


### PR DESCRIPTION
cc: @cgriggs01

Add a `website/` directory with a sidebar, an index page with general provider information, and pages for the `stackpath_compute_workload` and `stackpath_compute_network_policy` resources. 

This addresses one of the points raised in #8 :

> You will need to build website documentation in a website/ directory that will be hosted on [Terraform.io](https://terraform.io/docs/providers/index.html) for each resource and data source, these are all written in Markdown with a ruby layout file for the sidebar formatting. Check out the [Github provider](https://github.com/terraform-providers/terraform-provider-github) website docs as a good example.
