### PR TITLE
Clarify stack ID and common underlying errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
   include:
     - go: 1.11.x
     - go: 1.12.x
+    - go: 1.13.x
     - go: 1.x
     - go: tip
   allow_failures:

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ provider "stackpath" {
   # only allow version 0.1 of the StackPath provider to be used
   version = "~> 0.1"
   # ID of the stack that resources should be created in
-  stack = "{{ stack-id }}"
+  stack_id = "{{ stack-id }}"
   # The API credentials that should be used for authentication
   client_id = "{{ client-id }}"
   client_secret = "{{ client-secret }}"

--- a/examples/compute-nginx-with-network-policy/workload.tf
+++ b/examples/compute-nginx-with-network-policy/workload.tf
@@ -1,6 +1,6 @@
 # Define the variables that are needed to execute this plan.
 
-variable "stackpath_stack" {
+variable "stackpath_stack_id" {
   description = "The StackPath ID of the Stack you want to create these resources in."
   type        = string
 }
@@ -16,7 +16,7 @@ variable "stackpath_client_secret" {
 }
 
 provider "stackpath" {
-  stack         = var.stackpath_stack
+  stack_id      = var.stackpath_stack_id
   client_id     = var.stackpath_client_id
   client_secret = var.stackpath_client_secret
 }

--- a/examples/multi-cloud-load-balancer/provider.tf
+++ b/examples/multi-cloud-load-balancer/provider.tf
@@ -1,5 +1,5 @@
 # StackPath provider variables
-variable "stackpath_stack" {}
+variable "stackpath_stack_id" {}
 variable "stackpath_client_id" {}
 variable "stackpath_client_secret" {}
 
@@ -17,7 +17,7 @@ variable "gcp_region" {}
 variable "gcp_zone" {}
 
 provider "stackpath" {
-  stack         = "${var.stackpath_stack}"
+  stack_id      = "${var.stackpath_stack_id}"
   client_id     = "${var.stackpath_client_id}"
   client_secret = "${var.stackpath_client_secret}"
 }

--- a/stackpath/config.go
+++ b/stackpath/config.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
 	"time"
 
@@ -30,7 +29,7 @@ const (
 // Config is used to configure the StackPath provider.
 type Config struct {
 	// The Stack in which all resources should be created
-	Stack string
+	StackID string
 
 	// The Client ID that should be used to retrieve an access token. This
 	// option must not be used with the access token option.
@@ -60,18 +59,6 @@ type Config struct {
 // LoadAndValidate will load the configuration and validate the configuration
 // options. An error will be returned when the configuration is invalid.
 func (c *Config) LoadAndValidate() error {
-	if v := os.Getenv("STACKPATH_CLIENT_ID"); v != "" {
-		c.ClientID = v
-	}
-	if v := os.Getenv("STACKPATH_CLIENT_SECRET"); v != "" {
-		c.ClientSecret = v
-	}
-	if v := os.Getenv("STACKPATH_STACK"); v != "" {
-		c.Stack = v
-	}
-	if v := os.Getenv("STACKPATH_BASE_URL"); v != "" {
-		c.BaseURL = strings.TrimRight(v, "/")
-	}
 	if c.ClientID == "" && c.ClientSecret == "" && c.AccessToken == "" {
 		// Require the user to provide at least one form of authentication
 		return fmt.Errorf("must provide either an access_token or a client_id and client_secret")
@@ -98,7 +85,7 @@ func (c *Config) LoadAndValidate() error {
 		c.BaseURL = baseURL.Host
 	}
 
-	if c.Stack == "" {
+	if c.StackID == "" {
 		// Require the user to provide a stack
 		return fmt.Errorf("must provide a stack to create resources in")
 	}

--- a/stackpath/errors.go
+++ b/stackpath/errors.go
@@ -1,0 +1,65 @@
+package stackpath
+
+import (
+	"net/url"
+	"strings"
+
+	"golang.org/x/oauth2"
+)
+
+// InvalidClientSecretError models when a StackPath API OAuth 2 client ID is
+// invalid, either due to an invalid format or because the client ID does not
+// exist at StackPath.
+type InvalidClientIDError struct {
+	error
+	Err error
+}
+
+// NewInvalidClientIDError wraps an existing error as an invalid client ID error.
+func NewInvalidClientIDError(err error) *InvalidClientIDError {
+	return &InvalidClientIDError{Err: err}
+}
+
+// Error returns a human-readable invalid client ID error message.
+func (e *InvalidClientIDError) Error() string {
+	return "invalid or unknown StackPath client ID"
+}
+
+// InvalidClientSecretError models when a StackPath API OAuth 2 client ID is
+// correct, but the client secret is incorrect.
+type InvalidClientSecretError struct {
+	error
+	Err error
+}
+
+// NewInvalidClientSecretError wraps an existing error as an invalid client
+// secret error.
+func NewInvalidClientSecretError(err error) *InvalidClientSecretError {
+	return &InvalidClientSecretError{Err: err}
+}
+
+// Error returns a human-readable invalid client secret error message.
+func (e *InvalidClientSecretError) Error() string {
+	return "invalid StackPath client secret"
+}
+
+// NewStackPathError factories common StackPath error scenarios into their own
+// error types, or returns the original error.
+func NewStackPathError(err error) error {
+	switch err.(type) {
+	// Look for errors performing underlying OAuth 2 authentication.
+	case *url.Error:
+		switch err.(*url.Error).Err.(type) {
+		case *oauth2.RetrieveError:
+			if strings.HasPrefix(err.(*url.Error).Err.(*oauth2.RetrieveError).Error(), "oauth2: cannot fetch token: 404 Not Found") {
+				return NewInvalidClientIDError(err)
+			}
+
+			if strings.HasPrefix(err.(*url.Error).Err.(*oauth2.RetrieveError).Error(), "oauth2: cannot fetch token: 401 Unauthorized") {
+				return NewInvalidClientSecretError(err)
+			}
+		}
+	}
+
+	return err
+}

--- a/stackpath/errors.go
+++ b/stackpath/errors.go
@@ -9,13 +9,11 @@ import (
 // InvalidClientSecretError models when a StackPath API OAuth 2 client ID is
 // invalid, either due to an invalid format or because the client ID does not
 // exist at StackPath.
-type InvalidClientIDError struct {
-	Err error
-}
+type InvalidClientIDError struct{}
 
 // NewInvalidClientIDError wraps an existing error as an invalid client ID error.
-func NewInvalidClientIDError(err error) *InvalidClientIDError {
-	return &InvalidClientIDError{Err: err}
+func NewInvalidClientIDError() *InvalidClientIDError {
+	return &InvalidClientIDError{}
 }
 
 // Error returns a human-readable invalid client ID error message.
@@ -25,14 +23,12 @@ func (e *InvalidClientIDError) Error() string {
 
 // InvalidClientSecretError models when a StackPath API OAuth 2 client ID is
 // correct, but the client secret is incorrect.
-type InvalidClientSecretError struct {
-	Err error
-}
+type InvalidClientSecretError struct{}
 
 // NewInvalidClientSecretError wraps an existing error as an invalid client
 // secret error.
-func NewInvalidClientSecretError(err error) *InvalidClientSecretError {
-	return &InvalidClientSecretError{Err: err}
+func NewInvalidClientSecretError() *InvalidClientSecretError {
+	return &InvalidClientSecretError{}
 }
 
 // Error returns a human-readable invalid client secret error message.
@@ -52,11 +48,11 @@ func NewStackPathError(err error) error {
 			// A 401 Unauthorized error means the client ID was valid, but the
 			// corresponding secret wasn't.
 			case 401:
-				return NewInvalidClientSecretError(err)
+				return NewInvalidClientSecretError()
 
 			// A 404 Not Found error means the client ID didn't exist.
 			case 404:
-				return NewInvalidClientIDError(err)
+				return NewInvalidClientIDError()
 			}
 		}
 	}

--- a/stackpath/errors_test.go
+++ b/stackpath/errors_test.go
@@ -1,0 +1,62 @@
+package stackpath
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"golang.org/x/oauth2"
+)
+
+func TestBuildAnInvalidClientIDError(t *testing.T) {
+	err := NewStackPathError(&url.Error{
+		Err: &oauth2.RetrieveError{
+			Response: &http.Response{
+				Status: "404 Not Found",
+			},
+		},
+	})
+
+	switch err.(type) {
+	case *InvalidClientIDError:
+		if err.Error() != "invalid or unknown StackPath client ID" {
+			t.Errorf("An invalid client ID error has the unexpected error message \"%s\"", err.Error())
+		}
+	default:
+		t.Errorf("NewStackPathError() built an incorrect error type. Expected InvalidClientIDError but got %t", err)
+	}
+}
+
+func TestBuildAnInvalidClientSecretError(t *testing.T) {
+	err := NewStackPathError(&url.Error{
+		Err: &oauth2.RetrieveError{
+			Response: &http.Response{
+				Status: "401 Unauthorized",
+			},
+		},
+	})
+
+	switch err.(type) {
+	case *InvalidClientSecretError:
+		if err.Error() != "invalid StackPath client secret" {
+			t.Errorf("An invalid client ID error has the unexpected error message \"%s\"", err.Error())
+		}
+	default:
+		t.Errorf("NewStackPathError() built an incorrect error type. Expected InvalidClientSecretError but got %t", err)
+	}
+}
+
+func TestBuildANonStackPathError(t *testing.T) {
+	type TestError struct {
+		error
+	}
+
+	err := NewStackPathError(&TestError{errors.New("foo")})
+
+	switch err.(type) {
+	case *TestError:
+	default:
+		t.Errorf("NewStackPathError built an incorrect error type. Expected TestError but got %t", err)
+	}
+}

--- a/stackpath/errors_test.go
+++ b/stackpath/errors_test.go
@@ -13,7 +13,7 @@ func TestBuildAnInvalidClientIDError(t *testing.T) {
 	err := NewStackPathError(&url.Error{
 		Err: &oauth2.RetrieveError{
 			Response: &http.Response{
-				Status: "404 Not Found",
+				StatusCode: 404,
 			},
 		},
 	})
@@ -32,7 +32,7 @@ func TestBuildAnInvalidClientSecretError(t *testing.T) {
 	err := NewStackPathError(&url.Error{
 		Err: &oauth2.RetrieveError{
 			Response: &http.Response{
-				Status: "401 Unauthorized",
+				StatusCode: 401,
 			},
 		},
 	})

--- a/stackpath/provider.go
+++ b/stackpath/provider.go
@@ -13,23 +13,26 @@ func Provider() terraform.ResourceProvider {
 	return &schema.Provider{
 		Schema: map[string]*schema.Schema{
 			"client_id": &schema.Schema{
-				Type:      schema.TypeString,
-				Sensitive: true,
-				Optional:  true,
+				Type:        schema.TypeString,
+				Sensitive:   true,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("STACKPATH_CLIENT_ID", ""),
 			},
 			"client_secret": &schema.Schema{
-				Type:      schema.TypeString,
-				Sensitive: true,
-				Optional:  true,
+				Type:        schema.TypeString,
+				Sensitive:   true,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("STACKPATH_CLIENT_SECRET", ""),
 			},
 			"access_token": &schema.Schema{
 				Type:      schema.TypeString,
 				Sensitive: true,
 				Optional:  true,
 			},
-			"stack": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
+			"stack_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("STACKPATH_STACK_ID", ""),
 			},
 			"base_url": &schema.Schema{
 				Type:     schema.TypeString,
@@ -48,7 +51,7 @@ func Provider() terraform.ResourceProvider {
 
 func configureProvider(data *schema.ResourceData) (interface{}, error) {
 	config := &Config{
-		Stack:   data.Get("stack").(string),
+		StackID: data.Get("stack_id").(string),
 		BaseURL: data.Get("base_url").(string),
 	}
 

--- a/stackpath/provider.go
+++ b/stackpath/provider.go
@@ -38,7 +38,7 @@ func Provider() terraform.ResourceProvider {
 				Type:     schema.TypeString,
 				Optional: true,
 				// Default to the official StackPath API
-				Default: defaultBaseURL,
+				DefaultFunc: schema.EnvDefaultFunc("STACKPATH_BASE_URL", defaultBaseURL),
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{

--- a/stackpath/provider_test.go
+++ b/stackpath/provider_test.go
@@ -1,18 +1,47 @@
 package stackpath
 
 import (
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
 
-var (
-	testAccProvider  = Provider().(*schema.Provider)
+var clientID, clientSecret, stackID string
+var testAccProviders map[string]terraform.ResourceProvider
+var testAccProvider *schema.Provider
+
+func init() {
+	clientID = os.Getenv("STACKPATH_CLIENT_ID")
+	clientSecret = os.Getenv("STACKPATH_CLIENT_SECRET")
+	stackID = os.Getenv("STACKPATH_STACK_ID")
+	testAccProvider = Provider().(*schema.Provider)
 	testAccProviders = map[string]terraform.ResourceProvider{
 		"stackpath": testAccProvider,
 	}
-)
+}
+
+func testAccPreCheck(t *testing.T) {
+	missingVars := make([]string, 0)
+
+	if clientID == "" {
+		missingVars = append(missingVars, "STACKPATH_CLIENT_ID")
+	}
+
+	if clientSecret == "" {
+		missingVars = append(missingVars, "STACKPATH_CLIENT_SECRET")
+	}
+
+	if stackID == "" {
+		missingVars = append(missingVars, "STACKPATH_STACK_ID")
+	}
+
+	if len(missingVars) > 0 {
+		t.Fatalf("%s must be set for acceptance tests", strings.Join(missingVars, ","))
+	}
+}
 
 func TestProvider(t *testing.T) {
 	if err := Provider().(*schema.Provider).InternalValidate(); err != nil {

--- a/stackpath/resource_stackpath_compute_network_policy.go
+++ b/stackpath/resource_stackpath_compute_network_policy.go
@@ -364,7 +364,7 @@ func resourceComputeNetworkPolicyCreate(data *schema.ResourceData, meta interfac
 		},
 	}, nil)
 	if err != nil {
-		return fmt.Errorf("failed to create network policy: %v", err)
+		return fmt.Errorf("failed to create network policy: %v", NewStackPathError(err))
 	}
 
 	data.SetId(resp.Payload.NetworkPolicy.ID)
@@ -385,7 +385,7 @@ func resourceComputeNetworkPolicyRead(data *schema.ResourceData, meta interface{
 		data.SetId("")
 		return nil
 	} else if err != nil {
-		return err
+		return fmt.Errorf("failed to read network policy: %v", NewStackPathError(err))
 	}
 
 	data.Set("name", resp.Payload.NetworkPolicy.Name)
@@ -442,7 +442,7 @@ func resourceComputeNetworkPolicyUpdate(data *schema.ResourceData, meta interfac
 		data.SetId("")
 		return nil
 	} else if err != nil {
-		return err
+		return fmt.Errorf("failed to update network policy: %v", NewStackPathError(err))
 	}
 
 	return resourceComputeNetworkPolicyRead(data, meta)
@@ -456,7 +456,7 @@ func resourceComputeNetworkPolicyDelete(data *schema.ResourceData, meta interfac
 		NetworkPolicyID: data.Id(),
 	}, nil)
 	if err != nil {
-		return fmt.Errorf("failed to delete network policy: %v", err)
+		return fmt.Errorf("failed to delete network policy: %v", NewStackPathError(err))
 	}
 
 	data.SetId("")

--- a/stackpath/resource_stackpath_compute_network_policy.go
+++ b/stackpath/resource_stackpath_compute_network_policy.go
@@ -358,7 +358,7 @@ func resourceComputeNetworkPolicyCreate(data *schema.ResourceData, meta interfac
 	config := meta.(*Config)
 	resp, err := config.ipam.CreateNetworkPolicy(&client.CreateNetworkPolicyParams{
 		Context:              context.Background(),
-		NetworkPolicyStackID: config.Stack,
+		NetworkPolicyStackID: config.StackID,
 		Body: &models.V1CreateNetworkPolicyRequest{
 			NetworkPolicy: convertComputeNetworkPolicy(data),
 		},
@@ -375,7 +375,7 @@ func resourceComputeNetworkPolicyRead(data *schema.ResourceData, meta interface{
 	config := meta.(*Config)
 
 	resp, err := config.ipam.GetNetworkPolicy(&client.GetNetworkPolicyParams{
-		StackID:         config.Stack,
+		StackID:         config.StackID,
 		NetworkPolicyID: data.Id(),
 		Context:         context.Background(),
 	}, nil)
@@ -431,7 +431,7 @@ func resourceComputeNetworkPolicyUpdate(data *schema.ResourceData, meta interfac
 
 	_, err := config.ipam.UpdateNetworkPolicy(&client.UpdateNetworkPolicyParams{
 		Context:              context.Background(),
-		NetworkPolicyStackID: config.Stack,
+		NetworkPolicyStackID: config.StackID,
 		Body: &models.V1UpdateNetworkPolicyRequest{
 			NetworkPolicy: networkPolicy,
 		},
@@ -452,7 +452,7 @@ func resourceComputeNetworkPolicyDelete(data *schema.ResourceData, meta interfac
 	config := meta.(*Config)
 	_, err := config.ipam.DeleteNetworkPolicy(&client.DeleteNetworkPolicyParams{
 		Context:         context.Background(),
-		StackID:         config.Stack,
+		StackID:         config.StackID,
 		NetworkPolicyID: data.Id(),
 	}, nil)
 	if err != nil {

--- a/stackpath/resource_stackpath_compute_network_policy_test.go
+++ b/stackpath/resource_stackpath_compute_network_policy_test.go
@@ -18,7 +18,10 @@ func TestAccComputeNetworkPolicy(t *testing.T) {
 	networkPolicy := &models.V1NetworkPolicy{}
 
 	resource.Test(t, resource.TestCase{
-		Providers:    testAccProviders,
+		Providers: testAccProviders,
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
 		CheckDestroy: testAccComputeNetworkPolicyCheckDestroy(),
 		Steps: []resource.TestStep{
 			resource.TestStep{
@@ -45,7 +48,7 @@ func testAccComputeCheckNetworkPolicyExists(name string, policy *models.V1Networ
 		config := testAccProvider.Meta().(*Config)
 		found, err := config.ipam.GetNetworkPolicy(&client.GetNetworkPolicyParams{
 			NetworkPolicyID: rs.Primary.ID,
-			StackID:         config.Stack,
+			StackID:         config.StackID,
 			Context:         context.Background(),
 		}, nil)
 		if err != nil {
@@ -68,11 +71,11 @@ func testAccComputeNetworkPolicyCheckDestroy() resource.TestCheckFunc {
 			}
 
 			resp, err := config.ipam.GetNetworkPolicy(&client.GetNetworkPolicyParams{
-				StackID:         config.Stack,
+				StackID:         config.StackID,
 				NetworkPolicyID: rs.Primary.ID,
 				Context:         context.Background(),
 			}, nil)
-			// Since compute workloads are deleted asyncronously, we want to look at the fact that
+			// Since compute workloads are deleted asynchronously, we want to look at the fact that
 			// the deleteRequestedAt timestamp was set on the workload. This field is used to indicate
 			// that the workload is being deleted.
 			if err == nil && resp.Payload.NetworkPolicy.Metadata.DeleteRequestedAt == nil {

--- a/stackpath/resource_stackpath_compute_workload.go
+++ b/stackpath/resource_stackpath_compute_workload.go
@@ -5,11 +5,10 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/stackpath/terraform-provider-stackpath/stackpath/internal/client"
 	workload "github.com/stackpath/terraform-provider-stackpath/stackpath/internal/client"
 	"github.com/stackpath/terraform-provider-stackpath/stackpath/internal/models"
-
-	"github.com/hashicorp/terraform/helper/schema"
 )
 
 // annotation keys that should be ignored when diffing the state of a workload
@@ -376,7 +375,7 @@ func resourceComputeWorkloadCreate(data *schema.ResourceData, meta interface{}) 
 		},
 	}, nil)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create compute workload: %v", NewStackPathError(err))
 	}
 
 	// Set the ID based on the workload created in the API
@@ -401,7 +400,7 @@ func resourceComputeWorkloadUpdate(data *schema.ResourceData, meta interface{}) 
 		data.SetId("")
 		return nil
 	} else if err != nil {
-		return err
+		return fmt.Errorf("failed to update compute workload: %v", NewStackPathError(err))
 	}
 	return resourceComputeWorkloadRead(data, meta)
 }
@@ -420,7 +419,7 @@ func resourceComputeWorkloadRead(data *schema.ResourceData, meta interface{}) er
 		data.SetId("")
 		return nil
 	} else if err != nil {
-		return err
+		return fmt.Errorf("failed to read compute workload: %v", NewStackPathError(err))
 	}
 
 	if err := flattenComputeWorkload(data, resp.Payload.Workload); err != nil {
@@ -449,7 +448,7 @@ func resourceComputeWorkloadReadInstances(data *schema.ResourceData, meta interf
 		}
 		resp, err := config.compute.GetWorkloadInstances(params, nil)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to read compute workload instances: %v", NewStackPathError(err))
 		}
 		for _, result := range resp.Payload.Results {
 			instances = append(instances, flattenComputeWorkloadInstance(result))
@@ -482,7 +481,7 @@ func resourceComputeWorkloadDelete(data *schema.ResourceData, meta interface{}) 
 		data.SetId("")
 		return nil
 	} else if err != nil {
-		return err
+		return fmt.Errorf("failed to delete compute workload: %v", NewStackPathError(err))
 	}
 	return nil
 }

--- a/stackpath/resource_stackpath_compute_workload.go
+++ b/stackpath/resource_stackpath_compute_workload.go
@@ -370,7 +370,7 @@ func resourceComputeWorkloadCreate(data *schema.ResourceData, meta interface{}) 
 	// Create the workload
 	resp, err := config.compute.CreateWorkload(&workload.CreateWorkloadParams{
 		Context: context.Background(),
-		StackID: config.Stack,
+		StackID: config.StackID,
 		Body: &models.V1CreateWorkloadRequest{
 			Workload: convertComputeWorkload(data),
 		},
@@ -389,7 +389,7 @@ func resourceComputeWorkloadUpdate(data *schema.ResourceData, meta interface{}) 
 	config := meta.(*Config)
 	_, err := config.compute.UpdateWorkload(&workload.UpdateWorkloadParams{
 		Context:    context.Background(),
-		StackID:    config.Stack,
+		StackID:    config.StackID,
 		WorkloadID: data.Id(),
 		Body: &models.V1UpdateWorkloadRequest{
 			Workload: convertComputeWorkload(data),
@@ -411,7 +411,7 @@ func resourceComputeWorkloadRead(data *schema.ResourceData, meta interface{}) er
 
 	resp, err := config.compute.GetWorkload(&workload.GetWorkloadParams{
 		Context:    context.Background(),
-		StackID:    config.Stack,
+		StackID:    config.StackID,
 		WorkloadID: data.Id(),
 	}, nil)
 	if c, ok := err.(interface{ Code() int }); ok && c.Code() == http.StatusNotFound {
@@ -439,7 +439,7 @@ func resourceComputeWorkloadReadInstances(data *schema.ResourceData, meta interf
 	var instances []interface{}
 	for {
 		params := &client.GetWorkloadInstancesParams{
-			StackID:          config.Stack,
+			StackID:          config.StackID,
 			WorkloadID:       data.Id(),
 			Context:          context.Background(),
 			PageRequestFirst: &pageSize,
@@ -473,7 +473,7 @@ func resourceComputeWorkloadDelete(data *schema.ResourceData, meta interface{}) 
 
 	_, err := config.compute.DeleteWorkload(&workload.DeleteWorkloadParams{
 		Context:    context.Background(),
-		StackID:    config.Stack,
+		StackID:    config.StackID,
 		WorkloadID: data.Id(),
 	}, nil)
 	if c, ok := err.(interface{ Code() int }); ok && c.Code() == http.StatusNotFound {

--- a/stackpath/resource_stackpath_compute_workload_test.go
+++ b/stackpath/resource_stackpath_compute_workload_test.go
@@ -23,7 +23,10 @@ func TestComputeWorkloadContainers(t *testing.T) {
 	nameSuffix := strconv.Itoa(int(time.Now().Unix()))
 
 	resource.Test(t, resource.TestCase{
-		Providers:    testAccProviders,
+		Providers: testAccProviders,
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
 		CheckDestroy: testAccComputeWorkloadCheckDestroy(),
 		Steps: []resource.TestStep{
 			resource.TestStep{
@@ -107,7 +110,10 @@ func TestComputeWorkloadContainersAdditionalVolume(t *testing.T) {
 	nameSuffix := strconv.Itoa(int(time.Now().Unix()))
 
 	resource.Test(t, resource.TestCase{
-		Providers:    testAccProviders,
+		Providers: testAccProviders,
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
 		CheckDestroy: testAccComputeWorkloadCheckDestroy(),
 		Steps: []resource.TestStep{
 			resource.TestStep{
@@ -130,7 +136,10 @@ func TestComputeWorkloadVirtualMachines(t *testing.T) {
 	nameSuffix := strconv.Itoa(int(time.Now().Unix()))
 
 	resource.Test(t, resource.TestCase{
-		Providers:    testAccProviders,
+		Providers: testAccProviders,
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
 		CheckDestroy: testAccComputeWorkloadCheckDestroy(),
 		Steps: []resource.TestStep{
 			resource.TestStep{
@@ -156,7 +165,7 @@ func testAccComputeWorkloadCheckDestroy() resource.TestCheckFunc {
 			}
 
 			resp, err := config.compute.GetWorkload(&compute.GetWorkloadParams{
-				StackID:    config.Stack,
+				StackID:    config.StackID,
 				WorkloadID: rs.Primary.ID,
 				Context:    context.Background(),
 			}, nil)
@@ -359,7 +368,7 @@ func testAccComputeWorkloadCheckExists(name string, workload *models.V1Workload)
 		config := testAccProvider.Meta().(*Config)
 		found, err := config.compute.GetWorkload(&compute.GetWorkloadParams{
 			WorkloadID: rs.Primary.ID,
-			StackID:    config.Stack,
+			StackID:    config.StackID,
 			Context:    context.Background(),
 		}, nil)
 		if err != nil {

--- a/stackpath/resource_stackpath_compute_workload_test.go
+++ b/stackpath/resource_stackpath_compute_workload_test.go
@@ -80,7 +80,7 @@ func TestComputeWorkloadContainers(t *testing.T) {
 			},
 			resource.TestStep{
 				ExpectError: emptyImagePullSecrets,
-				Config: testComputeWorkloadConfigContainerImagePullCredentials(nameSuffix),
+				Config:      testComputeWorkloadConfigContainerImagePullCredentials(nameSuffix),
 				Check: resource.ComposeTestCheckFunc(
 					testAccComputeWorkloadCheckExists("stackpath_compute_workload.foo", workload),
 					testAccComputeWorkloadCheckContainerImage(workload, "app", "nginx:latest"),
@@ -89,7 +89,7 @@ func TestComputeWorkloadContainers(t *testing.T) {
 			},
 			resource.TestStep{
 				ExpectError: emptyImagePullSecrets,
-				Config: testComputeWorkloadConfigAutoScalingConfiguration(nameSuffix),
+				Config:      testComputeWorkloadConfigAutoScalingConfiguration(nameSuffix),
 				Check: resource.ComposeTestCheckFunc(
 					testAccComputeWorkloadCheckExists("stackpath_compute_workload.foo", workload),
 					testAccComputeWorkloadCheckContainerImage(workload, "app", "nginx:latest"),

--- a/stackpath/structure_compute_workload.go
+++ b/stackpath/structure_compute_workload.go
@@ -446,10 +446,12 @@ func flattenComputeWorkloadImagePullCredentials(prefix string, data *schema.Reso
 	creds := make([]interface{}, data.Get(prefix+".#").(int))
 	for _, c := range credentials {
 		data := map[string]interface{}{
-			"docker_registry": map[string]interface{}{
-				"server":   c.DockerRegistry.Server,
-				"username": c.DockerRegistry.Username,
-				"email":    c.DockerRegistry.Email,
+			"docker_registry": []map[string]interface{}{
+				{
+					"server":   c.DockerRegistry.Server,
+					"username": c.DockerRegistry.Username,
+					"email":    c.DockerRegistry.Email,
+				},
 			},
 		}
 		if index, exists := ordered[c.DockerRegistry.Server]; exists {

--- a/stackpath/structure_compute_workload.go
+++ b/stackpath/structure_compute_workload.go
@@ -660,9 +660,9 @@ func flattenComputeWorkloadHTTPGetAction(httpGet *models.V1HTTPGetAction) []inte
 
 	return []interface{}{
 		map[string]interface{}{
-			"port":    httpGet.Port,
-			"path":    httpGet.Path,
-			"scheme":  httpGet.Scheme,
+			"port":         httpGet.Port,
+			"path":         httpGet.Path,
+			"scheme":       httpGet.Scheme,
 			"http_headers": flattenStringMap(httpGet.HTTPHeaders),
 		},
 	}

--- a/stackpath/structure_compute_workload.go
+++ b/stackpath/structure_compute_workload.go
@@ -661,7 +661,7 @@ func flattenComputeWorkloadHTTPGetAction(httpGet *models.V1HTTPGetAction) []inte
 			"port":    httpGet.Port,
 			"path":    httpGet.Path,
 			"scheme":  httpGet.Scheme,
-			"headers": flattenStringMap(httpGet.HTTPHeaders),
+			"http_headers": flattenStringMap(httpGet.HTTPHeaders),
 		},
 	}
 }

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -19,7 +19,7 @@ Use the navigation to the left to read about the available resources.
 ```hcl
 # Configure the StackPath Provider
 provider "stackpath" {
-  stack         = "${var.stackpath_stack}"
+  stack_id      = "${var.stackpath_stack_id}"
   client_id     = "${var.stackpath_client_id}"
   client_secret = "${var.stackpath_client_secret}"
 }
@@ -34,6 +34,6 @@ resource "stackpath_compute_workload" "my-compute-workload" {
 
 The following arguments are supported in the `provider` block:
 
-* `stack` - (Required) This is the ID of stack that all new services are provisioned to. Stacks are folder-like organizational units on the StackPath platform and are typically used to organize services by project or user. Stack IDs are UUID v4 formatted strings. `stack` can be defined in either the provider definition or the `STACKPATH_STACK` environment variable.
+* `stack_id` - (Required) This is the ID of stack that all new services are provisioned to. Stacks are folder-like organizational units on the StackPath platform and are typically used to organize services by project or user. Stack IDs are UUID v4 formatted strings. `stack` can be defined in either the provider definition or the `STACKPATH_STACK` environment variable.
 * `client_id` - (Required) This is the API client ID of the StackPath user that will interact with Terraform. All services provisioned at StackPath through Terraform belong to their creating user. `client_id` can be defined in either the provider definition or the `STACKPATH_CLIENT_ID` environment variable.
 * `client_secret` - (Required) This is the API client secret of the StackPath user that will interact with Terraform. Client secrets should be stored securely and not exposed to the public. `client_secret` can be defined in either the provider definition or the `STACKPATH_CLIENT_SECRET` environment variable.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -34,6 +34,6 @@ resource "stackpath_compute_workload" "my-compute-workload" {
 
 The following arguments are supported in the `provider` block:
 
-* `stack_id` - (Required) This is the ID of stack that all new services are provisioned to. Stacks are folder-like organizational units on the StackPath platform and are typically used to organize services by project or user. Stack IDs are UUID v4 formatted strings. `stack` can be defined in either the provider definition or the `STACKPATH_STACK` environment variable.
+* `stack_id` - (Required) This is the ID of stack that all new services are provisioned to. Stacks are folder-like organizational units on the StackPath platform and are typically used to organize services by project or user. Stack IDs are UUID v4 formatted strings. `stack_id` can be defined in either the provider definition or the `STACKPATH_STACK_ID` environment variable.
 * `client_id` - (Required) This is the API client ID of the StackPath user that will interact with Terraform. All services provisioned at StackPath through Terraform belong to their creating user. `client_id` can be defined in either the provider definition or the `STACKPATH_CLIENT_ID` environment variable.
 * `client_secret` - (Required) This is the API client secret of the StackPath user that will interact with Terraform. Client secrets should be stored securely and not exposed to the public. `client_secret` can be defined in either the provider definition or the `STACKPATH_CLIENT_SECRET` environment variable.


### PR DESCRIPTION
cc: @scotwells 

* Help alleviate potential confusion discovered in #8 by renaming the provider `stack` field to `stack_id` and the corresponding environment variable to `STACKPATH_STACK_ID`, and adjust documentation to match.
* Use `DefaultFunc`s to fall back to environment variable values in the provider config.
* Check for necessary environment variables on functional test runs.
* Introduce an error handler that encapsulates common yet confusing underlying StackPath API errors, namely OAuth2 authentication issues.
* Preface StackPath API errors with more descriptive messages.