### PR TITLE
Migrate the package to github.com/terraform-providers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/stackpath/terraform-provider-stackpath
+module github.com/terraform-providers/terraform-provider-stackpath
 
 require (
 	github.com/go-openapi/errors v0.19.2

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/hashicorp/terraform/plugin"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath"
+	"github.com/terraform-providers/terraform-provider-stackpath/stackpath"
 )
 
 func main() {

--- a/stackpath/config.go
+++ b/stackpath/config.go
@@ -14,8 +14,8 @@ import (
 	"github.com/hashicorp/terraform/helper/pathorcontents"
 	"github.com/hashicorp/terraform/httpclient"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/internal/client"
-	"github.com/stackpath/terraform-provider-stackpath/version"
+	"github.com/terraform-providers/terraform-provider-stackpath/stackpath/internal/client"
+	"github.com/terraform-providers/terraform-provider-stackpath/version"
 
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/clientcredentials"

--- a/stackpath/internal/client/create_network_policy_parameters.go
+++ b/stackpath/internal/client/create_network_policy_parameters.go
@@ -17,7 +17,7 @@ import (
 
 	strfmt "github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/internal/models"
+	"github.com/terraform-providers/terraform-provider-stackpath/stackpath/internal/models"
 )
 
 // NewCreateNetworkPolicyParams creates a new CreateNetworkPolicyParams object

--- a/stackpath/internal/client/create_network_policy_responses.go
+++ b/stackpath/internal/client/create_network_policy_responses.go
@@ -13,7 +13,7 @@ import (
 
 	strfmt "github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/internal/models"
+	"github.com/terraform-providers/terraform-provider-stackpath/stackpath/internal/models"
 )
 
 // CreateNetworkPolicyReader is a Reader for the CreateNetworkPolicy structure.

--- a/stackpath/internal/client/create_workload_parameters.go
+++ b/stackpath/internal/client/create_workload_parameters.go
@@ -17,7 +17,7 @@ import (
 
 	strfmt "github.com/go-openapi/strfmt"
 
-	models "github.com/stackpath/terraform-provider-stackpath/stackpath/internal/models"
+	models "github.com/terraform-providers/terraform-provider-stackpath/stackpath/internal/models"
 )
 
 // NewCreateWorkloadParams creates a new CreateWorkloadParams object

--- a/stackpath/internal/client/create_workload_responses.go
+++ b/stackpath/internal/client/create_workload_responses.go
@@ -13,7 +13,7 @@ import (
 
 	strfmt "github.com/go-openapi/strfmt"
 
-	models "github.com/stackpath/terraform-provider-stackpath/stackpath/internal/models"
+	models "github.com/terraform-providers/terraform-provider-stackpath/stackpath/internal/models"
 )
 
 // CreateWorkloadReader is a Reader for the CreateWorkload structure.

--- a/stackpath/internal/client/delete_network_policy_responses.go
+++ b/stackpath/internal/client/delete_network_policy_responses.go
@@ -13,7 +13,7 @@ import (
 
 	strfmt "github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/internal/models"
+	"github.com/terraform-providers/terraform-provider-stackpath/stackpath/internal/models"
 )
 
 // DeleteNetworkPolicyReader is a Reader for the DeleteNetworkPolicy structure.

--- a/stackpath/internal/client/delete_workload_responses.go
+++ b/stackpath/internal/client/delete_workload_responses.go
@@ -13,7 +13,7 @@ import (
 
 	strfmt "github.com/go-openapi/strfmt"
 
-	models "github.com/stackpath/terraform-provider-stackpath/stackpath/internal/models"
+	models "github.com/terraform-providers/terraform-provider-stackpath/stackpath/internal/models"
 )
 
 // DeleteWorkloadReader is a Reader for the DeleteWorkload structure.

--- a/stackpath/internal/client/get_locations_responses.go
+++ b/stackpath/internal/client/get_locations_responses.go
@@ -13,7 +13,7 @@ import (
 
 	strfmt "github.com/go-openapi/strfmt"
 
-	models "github.com/stackpath/terraform-provider-stackpath/stackpath/internal/models"
+	models "github.com/terraform-providers/terraform-provider-stackpath/stackpath/internal/models"
 )
 
 // GetLocationsReader is a Reader for the GetLocations structure.

--- a/stackpath/internal/client/get_network_policies_responses.go
+++ b/stackpath/internal/client/get_network_policies_responses.go
@@ -13,7 +13,7 @@ import (
 
 	strfmt "github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/internal/models"
+	"github.com/terraform-providers/terraform-provider-stackpath/stackpath/internal/models"
 )
 
 // GetNetworkPoliciesReader is a Reader for the GetNetworkPolicies structure.

--- a/stackpath/internal/client/get_network_policy_responses.go
+++ b/stackpath/internal/client/get_network_policy_responses.go
@@ -13,7 +13,7 @@ import (
 
 	strfmt "github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/internal/models"
+	"github.com/terraform-providers/terraform-provider-stackpath/stackpath/internal/models"
 )
 
 // GetNetworkPolicyReader is a Reader for the GetNetworkPolicy structure.

--- a/stackpath/internal/client/get_workload_instances_responses.go
+++ b/stackpath/internal/client/get_workload_instances_responses.go
@@ -13,7 +13,7 @@ import (
 
 	strfmt "github.com/go-openapi/strfmt"
 
-	models "github.com/stackpath/terraform-provider-stackpath/stackpath/internal/models"
+	models "github.com/terraform-providers/terraform-provider-stackpath/stackpath/internal/models"
 )
 
 // GetWorkloadInstancesReader is a Reader for the GetWorkloadInstances structure.

--- a/stackpath/internal/client/get_workload_responses.go
+++ b/stackpath/internal/client/get_workload_responses.go
@@ -13,7 +13,7 @@ import (
 
 	strfmt "github.com/go-openapi/strfmt"
 
-	models "github.com/stackpath/terraform-provider-stackpath/stackpath/internal/models"
+	models "github.com/terraform-providers/terraform-provider-stackpath/stackpath/internal/models"
 )
 
 // GetWorkloadReader is a Reader for the GetWorkload structure.

--- a/stackpath/internal/client/get_workloads_responses.go
+++ b/stackpath/internal/client/get_workloads_responses.go
@@ -13,7 +13,7 @@ import (
 
 	strfmt "github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/internal/models"
+	"github.com/terraform-providers/terraform-provider-stackpath/stackpath/internal/models"
 )
 
 // GetWorkloadsReader is a Reader for the GetWorkloads structure.

--- a/stackpath/internal/client/update_network_policy_parameters.go
+++ b/stackpath/internal/client/update_network_policy_parameters.go
@@ -17,7 +17,7 @@ import (
 
 	strfmt "github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/internal/models"
+	"github.com/terraform-providers/terraform-provider-stackpath/stackpath/internal/models"
 )
 
 // NewUpdateNetworkPolicyParams creates a new UpdateNetworkPolicyParams object

--- a/stackpath/internal/client/update_network_policy_responses.go
+++ b/stackpath/internal/client/update_network_policy_responses.go
@@ -13,7 +13,7 @@ import (
 
 	strfmt "github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/internal/models"
+	"github.com/terraform-providers/terraform-provider-stackpath/stackpath/internal/models"
 )
 
 // UpdateNetworkPolicyReader is a Reader for the UpdateNetworkPolicy structure.

--- a/stackpath/internal/client/update_workload_parameters.go
+++ b/stackpath/internal/client/update_workload_parameters.go
@@ -17,7 +17,7 @@ import (
 
 	strfmt "github.com/go-openapi/strfmt"
 
-	models "github.com/stackpath/terraform-provider-stackpath/stackpath/internal/models"
+	models "github.com/terraform-providers/terraform-provider-stackpath/stackpath/internal/models"
 )
 
 // NewUpdateWorkloadParams creates a new UpdateWorkloadParams object

--- a/stackpath/internal/client/update_workload_responses.go
+++ b/stackpath/internal/client/update_workload_responses.go
@@ -13,7 +13,7 @@ import (
 
 	strfmt "github.com/go-openapi/strfmt"
 
-	models "github.com/stackpath/terraform-provider-stackpath/stackpath/internal/models"
+	models "github.com/terraform-providers/terraform-provider-stackpath/stackpath/internal/models"
 )
 
 // UpdateWorkloadReader is a Reader for the UpdateWorkload structure.

--- a/stackpath/resource_stackpath_compute_network_policy.go
+++ b/stackpath/resource_stackpath_compute_network_policy.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform/helper/schema"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/internal/client"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/internal/models"
+	"github.com/terraform-providers/terraform-provider-stackpath/stackpath/internal/client"
+	"github.com/terraform-providers/terraform-provider-stackpath/stackpath/internal/models"
 )
 
 func resourceComputeNetworkPolicy() *schema.Resource {

--- a/stackpath/resource_stackpath_compute_network_policy_test.go
+++ b/stackpath/resource_stackpath_compute_network_policy_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/internal/client"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/internal/models"
+	"github.com/terraform-providers/terraform-provider-stackpath/stackpath/internal/client"
+	"github.com/terraform-providers/terraform-provider-stackpath/stackpath/internal/models"
 )
 
 func TestAccComputeNetworkPolicy(t *testing.T) {

--- a/stackpath/resource_stackpath_compute_workload.go
+++ b/stackpath/resource_stackpath_compute_workload.go
@@ -6,9 +6,9 @@ import (
 	"net/http"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/internal/client"
-	workload "github.com/stackpath/terraform-provider-stackpath/stackpath/internal/client"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/internal/models"
+	"github.com/terraform-providers/terraform-provider-stackpath/stackpath/internal/client"
+	workload "github.com/terraform-providers/terraform-provider-stackpath/stackpath/internal/client"
+	"github.com/terraform-providers/terraform-provider-stackpath/stackpath/internal/models"
 )
 
 // annotation keys that should be ignored when diffing the state of a workload

--- a/stackpath/resource_stackpath_compute_workload_test.go
+++ b/stackpath/resource_stackpath_compute_workload_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 
-	compute "github.com/stackpath/terraform-provider-stackpath/stackpath/internal/client"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/internal/models"
+	compute "github.com/terraform-providers/terraform-provider-stackpath/stackpath/internal/client"
+	"github.com/terraform-providers/terraform-provider-stackpath/stackpath/internal/models"
 )
 
 func TestComputeWorkloadContainers(t *testing.T) {

--- a/stackpath/structure_compute_network_policy.go
+++ b/stackpath/structure_compute_network_policy.go
@@ -3,7 +3,7 @@ package stackpath
 import (
 	"github.com/hashicorp/terraform/helper/schema"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/internal/models"
+	"github.com/terraform-providers/terraform-provider-stackpath/stackpath/internal/models"
 )
 
 func convertComputeNetworkPolicy(data *schema.ResourceData) *models.V1NetworkPolicy {

--- a/stackpath/structure_compute_workload.go
+++ b/stackpath/structure_compute_workload.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/schema"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/internal/models"
+	"github.com/terraform-providers/terraform-provider-stackpath/stackpath/internal/models"
 )
 
 // convert from the terraform data structure to the workload data structure we need for API calls

--- a/stackpath/structure_compute_workload_instance.go
+++ b/stackpath/structure_compute_workload_instance.go
@@ -1,7 +1,7 @@
 package stackpath
 
 import (
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/internal/models"
+	"github.com/terraform-providers/terraform-provider-stackpath/stackpath/internal/models"
 )
 
 func flattenComputeWorkloadInstance(instance *models.Workloadv1Instance) map[string]interface{} {

--- a/stackpath/structure_core.go
+++ b/stackpath/structure_core.go
@@ -2,7 +2,7 @@ package stackpath
 
 import (
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/internal/models"
+	"github.com/terraform-providers/terraform-provider-stackpath/stackpath/internal/models"
 )
 
 func convertComputeMatchExpression(data []interface{}) []*models.V1MatchExpression {


### PR DESCRIPTION
Requested in #8, this migrates the provider's package from `github.com/stackpath/terraform-provider-stackpath` to `github.com/terraform-providers/terraform-provider-stackpath`. Migrating the package is needed for adoption by Terraform.