### PR TITLE
Fix a panic when flettening ordered selectors

### DIFF
--- a/stackpath/structure_core.go
+++ b/stackpath/structure_core.go
@@ -87,25 +87,25 @@ func convertIPAMToWorkloadStringMapEntry(mapEntries ipam_models.NetworkStringMap
 	return converted
 }
 
-// flattenComputeMatchExpressions flattens the provided workload match expressions
+// flattenComputeMatchExpressionsOrdered flattens the provided workload match expressions
 // with respect to the order of any existing match expressions defined in the provided
 // ResourceData. The prefix should be the flattened key of the list of match expressions
 // in the ResourceData.
 func flattenComputeMatchExpressionsOrdered(prefix string, data *schema.ResourceData, selectors []*workload_models.V1MatchExpression) []interface{} {
 	ordered := make(map[string]int, len(selectors))
-	for i, d := range selectors {
-		ordered[d.Key] = i
+	for i, selector := range selectors {
+		ordered[selector.Key] = i
 	}
-	s := make([]interface{}, len(selectors))
-	for _, v := range selectors {
+	flattened := make([]interface{}, len(selectors))
+	for _, selector := range selectors {
 		data := map[string]interface{}{
-			"key":      v.Key,
-			"operator": v.Operator,
-			"values":   flattenStringArray(v.Values),
+			"key":      selector.Key,
+			"operator": selector.Operator,
+			"values":   flattenStringArray(selector.Values),
 		}
-		s[ordered[v.Key]] = data
+		flattened[ordered[selector.Key]] = data
 	}
-	return s
+	return flattened
 }
 
 // flattenComputeMatchExpressions flattens the provided workload match expressions
@@ -113,15 +113,15 @@ func flattenComputeMatchExpressionsOrdered(prefix string, data *schema.ResourceD
 // is important, eg when using for diff logic, then flattenComputeMatchExpressionsOrdered
 // should be used.
 func flattenComputeMatchExpressions(selectors []*workload_models.V1MatchExpression) []interface{} {
-	s := make([]interface{}, len(selectors))
-	for i, v := range selectors {
-		s[i] = map[string]interface{}{
-			"key":      v.Key,
-			"operator": v.Operator,
-			"values":   flattenStringArray(v.Values),
+	flattened := make([]interface{}, len(selectors))
+	for i, selector := range selectors {
+		flattened[i] = map[string]interface{}{
+			"key":      selector.Key,
+			"operator": selector.Operator,
+			"values":   flattenStringArray(selector.Values),
 		}
 	}
-	return s
+	return flattened
 }
 
 func flattenStringMap(stringMap workload_models.V1StringMapEntry) map[string]interface{} {

--- a/stackpath/structure_core.go
+++ b/stackpath/structure_core.go
@@ -92,22 +92,18 @@ func convertIPAMToWorkloadStringMapEntry(mapEntries ipam_models.NetworkStringMap
 // ResourceData. The prefix should be the flattened key of the list of match expressions
 // in the ResourceData.
 func flattenComputeMatchExpressionsOrdered(prefix string, data *schema.ResourceData, selectors []*workload_models.V1MatchExpression) []interface{} {
-	ordered := make(map[string]int, data.Get(prefix+".#").(int))
+	ordered := make(map[string]int, len(selectors))
 	for i, d := range selectors {
 		ordered[d.Key] = i
 	}
-	s := make([]interface{}, data.Get(prefix+".#").(int))
+	s := make([]interface{}, len(selectors))
 	for _, v := range selectors {
 		data := map[string]interface{}{
 			"key":      v.Key,
 			"operator": v.Operator,
 			"values":   flattenStringArray(v.Values),
 		}
-		if index, exists := ordered[v.Key]; exists {
-			s[index] = data
-		} else {
-			s = append(s, data)
-		}
+		s[ordered[v.Key]] = data
 	}
 	return s
 }


### PR DESCRIPTION
Addresses #17.

Flattening ordered selectors would panic due when assigning a flattened selectors to an invalid slice index. Work around this by using the original selectors retrieved from StackPath to calculate the size of the intermediate and final slices. 

This also does a quick tidy of variable names in the file I was working in. Commit be1703428345f722a813e5243d464152a9a155f2 has the panic fix.