### PR TITLE
Use automatic token authentication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,12 @@
 # This GitHub action can publish assets for release when a tag is created.
 # Currently its setup to run on any tag that matches the pattern "v*" (ie. v0.1.0).
 #
-# This uses an action (paultyng/ghaction-import-gpg) that assumes you set your 
+# This uses an action (paultyng/ghaction-import-gpg) that assumes you set your
 # private key in the `GPG_PRIVATE_KEY` secret and passphrase in the `PASSPHRASE`
 # secret. If you would rather own your own GPG handling, please fork this action
 # or use an alternative one for key handling.
 #
-# You will need to pass the `--batch` flag to `gpg` in your signing step 
+# You will need to pass the `--batch` flag to `gpg` in your signing step
 # in `goreleaser` to indicate this is being used in a non-interactive mode.
 #
 name: Release
@@ -14,6 +14,10 @@ on:
   push:
     tags:
       - 'v*'
+
+permissions:
+  contents: write
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Automatic token authentication will allow the GitHub Action configuration
to define what permissions the implicit github token injected into the workflow
is given. This helps reduce the attack surface of providing an access token with
more than needed and reduces the number of github tokens we need to manage.

This adds the write permission for contents based on the issue opened on goreleaser
for what permissions are required.

References:
* https://github.com/goreleaser/goreleaser-action/issues/311
* https://docs.github.com/en/actions/security-guides/automatic-token-authentication