### PR TITLE
Use correct github token variable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,4 +47,4 @@ jobs:
           args: release --rm-dist
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Updating the release workflow to use `secrets.GITHUB_TOKEN` instead
of the existing GH_TOKEN secret that is configured for the repo.

Documentation: https://docs.github.com/en/actions/security-guides/automatic-token-authentication