### PR TITLE
ECSW-2754: Fix module path, major version upgrade to v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/stackpath/terraform-provider-stackpath
+module github.com/stackpath/terraform-provider-stackpath/v2
 
 require (
 	github.com/go-openapi/errors v0.20.0

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath"
 )
 
 func main() {

--- a/stackpath/api/ipam/ipam_client/edge_compute_networking_client.go
+++ b/stackpath/api/ipam/ipam_client/edge_compute_networking_client.go
@@ -10,8 +10,8 @@ import (
 	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_client/network_policies"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_client/virtual_private_cloud"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_client/network_policies"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_client/virtual_private_cloud"
 )
 
 // Default edge compute networking HTTP client.

--- a/stackpath/api/ipam/ipam_client/network_policies/create_network_policy_parameters.go
+++ b/stackpath/api/ipam/ipam_client/network_policies/create_network_policy_parameters.go
@@ -15,7 +15,7 @@ import (
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_models"
 )
 
 // NewCreateNetworkPolicyParams creates a new CreateNetworkPolicyParams object,
@@ -54,10 +54,12 @@ func NewCreateNetworkPolicyParamsWithHTTPClient(client *http.Client) *CreateNetw
 	}
 }
 
-/* CreateNetworkPolicyParams contains all the parameters to send to the API endpoint
-   for the create network policy operation.
+/*
+CreateNetworkPolicyParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the create network policy operation.
+
+	Typically these are written to a http.Request.
 */
 type CreateNetworkPolicyParams struct {
 

--- a/stackpath/api/ipam/ipam_client/network_policies/create_network_policy_responses.go
+++ b/stackpath/api/ipam/ipam_client/network_policies/create_network_policy_responses.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_models"
 )
 
 // CreateNetworkPolicyReader is a Reader for the CreateNetworkPolicy structure.
@@ -58,7 +58,8 @@ func NewCreateNetworkPolicyOK() *CreateNetworkPolicyOK {
 	return &CreateNetworkPolicyOK{}
 }
 
-/* CreateNetworkPolicyOK describes a response with status code 200, with default header values.
+/*
+	CreateNetworkPolicyOK describes a response with status code 200, with default header values.
 
 CreateNetworkPolicyOK create network policy o k
 */
@@ -90,7 +91,8 @@ func NewCreateNetworkPolicyUnauthorized() *CreateNetworkPolicyUnauthorized {
 	return &CreateNetworkPolicyUnauthorized{}
 }
 
-/* CreateNetworkPolicyUnauthorized describes a response with status code 401, with default header values.
+/*
+	CreateNetworkPolicyUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -122,7 +124,8 @@ func NewCreateNetworkPolicyInternalServerError() *CreateNetworkPolicyInternalSer
 	return &CreateNetworkPolicyInternalServerError{}
 }
 
-/* CreateNetworkPolicyInternalServerError describes a response with status code 500, with default header values.
+/*
+	CreateNetworkPolicyInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -156,7 +159,8 @@ func NewCreateNetworkPolicyDefault(code int) *CreateNetworkPolicyDefault {
 	}
 }
 
-/* CreateNetworkPolicyDefault describes a response with status code -1, with default header values.
+/*
+	CreateNetworkPolicyDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/ipam/ipam_client/network_policies/delete_network_policy_responses.go
+++ b/stackpath/api/ipam/ipam_client/network_policies/delete_network_policy_responses.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_models"
 )
 
 // DeleteNetworkPolicyReader is a Reader for the DeleteNetworkPolicy structure.
@@ -58,7 +58,8 @@ func NewDeleteNetworkPolicyNoContent() *DeleteNetworkPolicyNoContent {
 	return &DeleteNetworkPolicyNoContent{}
 }
 
-/* DeleteNetworkPolicyNoContent describes a response with status code 204, with default header values.
+/*
+	DeleteNetworkPolicyNoContent describes a response with status code 204, with default header values.
 
 No content
 */
@@ -79,7 +80,8 @@ func NewDeleteNetworkPolicyUnauthorized() *DeleteNetworkPolicyUnauthorized {
 	return &DeleteNetworkPolicyUnauthorized{}
 }
 
-/* DeleteNetworkPolicyUnauthorized describes a response with status code 401, with default header values.
+/*
+	DeleteNetworkPolicyUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -111,7 +113,8 @@ func NewDeleteNetworkPolicyInternalServerError() *DeleteNetworkPolicyInternalSer
 	return &DeleteNetworkPolicyInternalServerError{}
 }
 
-/* DeleteNetworkPolicyInternalServerError describes a response with status code 500, with default header values.
+/*
+	DeleteNetworkPolicyInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -145,7 +148,8 @@ func NewDeleteNetworkPolicyDefault(code int) *DeleteNetworkPolicyDefault {
 	}
 }
 
-/* DeleteNetworkPolicyDefault describes a response with status code -1, with default header values.
+/*
+	DeleteNetworkPolicyDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/ipam/ipam_client/network_policies/get_network_policies_responses.go
+++ b/stackpath/api/ipam/ipam_client/network_policies/get_network_policies_responses.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_models"
 )
 
 // GetNetworkPoliciesReader is a Reader for the GetNetworkPolicies structure.
@@ -58,7 +58,8 @@ func NewGetNetworkPoliciesOK() *GetNetworkPoliciesOK {
 	return &GetNetworkPoliciesOK{}
 }
 
-/* GetNetworkPoliciesOK describes a response with status code 200, with default header values.
+/*
+	GetNetworkPoliciesOK describes a response with status code 200, with default header values.
 
 GetNetworkPoliciesOK get network policies o k
 */
@@ -90,7 +91,8 @@ func NewGetNetworkPoliciesUnauthorized() *GetNetworkPoliciesUnauthorized {
 	return &GetNetworkPoliciesUnauthorized{}
 }
 
-/* GetNetworkPoliciesUnauthorized describes a response with status code 401, with default header values.
+/*
+	GetNetworkPoliciesUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -122,7 +124,8 @@ func NewGetNetworkPoliciesInternalServerError() *GetNetworkPoliciesInternalServe
 	return &GetNetworkPoliciesInternalServerError{}
 }
 
-/* GetNetworkPoliciesInternalServerError describes a response with status code 500, with default header values.
+/*
+	GetNetworkPoliciesInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -156,7 +159,8 @@ func NewGetNetworkPoliciesDefault(code int) *GetNetworkPoliciesDefault {
 	}
 }
 
-/* GetNetworkPoliciesDefault describes a response with status code -1, with default header values.
+/*
+	GetNetworkPoliciesDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/ipam/ipam_client/network_policies/get_network_policy_responses.go
+++ b/stackpath/api/ipam/ipam_client/network_policies/get_network_policy_responses.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_models"
 )
 
 // GetNetworkPolicyReader is a Reader for the GetNetworkPolicy structure.
@@ -58,7 +58,8 @@ func NewGetNetworkPolicyOK() *GetNetworkPolicyOK {
 	return &GetNetworkPolicyOK{}
 }
 
-/* GetNetworkPolicyOK describes a response with status code 200, with default header values.
+/*
+	GetNetworkPolicyOK describes a response with status code 200, with default header values.
 
 GetNetworkPolicyOK get network policy o k
 */
@@ -90,7 +91,8 @@ func NewGetNetworkPolicyUnauthorized() *GetNetworkPolicyUnauthorized {
 	return &GetNetworkPolicyUnauthorized{}
 }
 
-/* GetNetworkPolicyUnauthorized describes a response with status code 401, with default header values.
+/*
+	GetNetworkPolicyUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -122,7 +124,8 @@ func NewGetNetworkPolicyInternalServerError() *GetNetworkPolicyInternalServerErr
 	return &GetNetworkPolicyInternalServerError{}
 }
 
-/* GetNetworkPolicyInternalServerError describes a response with status code 500, with default header values.
+/*
+	GetNetworkPolicyInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -156,7 +159,8 @@ func NewGetNetworkPolicyDefault(code int) *GetNetworkPolicyDefault {
 	}
 }
 
-/* GetNetworkPolicyDefault describes a response with status code -1, with default header values.
+/*
+	GetNetworkPolicyDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/ipam/ipam_client/network_policies/update_network_policy_parameters.go
+++ b/stackpath/api/ipam/ipam_client/network_policies/update_network_policy_parameters.go
@@ -15,7 +15,7 @@ import (
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_models"
 )
 
 // NewUpdateNetworkPolicyParams creates a new UpdateNetworkPolicyParams object,
@@ -54,10 +54,12 @@ func NewUpdateNetworkPolicyParamsWithHTTPClient(client *http.Client) *UpdateNetw
 	}
 }
 
-/* UpdateNetworkPolicyParams contains all the parameters to send to the API endpoint
-   for the update network policy operation.
+/*
+UpdateNetworkPolicyParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the update network policy operation.
+
+	Typically these are written to a http.Request.
 */
 type UpdateNetworkPolicyParams struct {
 

--- a/stackpath/api/ipam/ipam_client/network_policies/update_network_policy_responses.go
+++ b/stackpath/api/ipam/ipam_client/network_policies/update_network_policy_responses.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_models"
 )
 
 // UpdateNetworkPolicyReader is a Reader for the UpdateNetworkPolicy structure.
@@ -58,7 +58,8 @@ func NewUpdateNetworkPolicyOK() *UpdateNetworkPolicyOK {
 	return &UpdateNetworkPolicyOK{}
 }
 
-/* UpdateNetworkPolicyOK describes a response with status code 200, with default header values.
+/*
+	UpdateNetworkPolicyOK describes a response with status code 200, with default header values.
 
 UpdateNetworkPolicyOK update network policy o k
 */
@@ -90,7 +91,8 @@ func NewUpdateNetworkPolicyUnauthorized() *UpdateNetworkPolicyUnauthorized {
 	return &UpdateNetworkPolicyUnauthorized{}
 }
 
-/* UpdateNetworkPolicyUnauthorized describes a response with status code 401, with default header values.
+/*
+	UpdateNetworkPolicyUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -122,7 +124,8 @@ func NewUpdateNetworkPolicyInternalServerError() *UpdateNetworkPolicyInternalSer
 	return &UpdateNetworkPolicyInternalServerError{}
 }
 
-/* UpdateNetworkPolicyInternalServerError describes a response with status code 500, with default header values.
+/*
+	UpdateNetworkPolicyInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -156,7 +159,8 @@ func NewUpdateNetworkPolicyDefault(code int) *UpdateNetworkPolicyDefault {
 	}
 }
 
-/* UpdateNetworkPolicyDefault describes a response with status code -1, with default header values.
+/*
+	UpdateNetworkPolicyDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/ipam/ipam_client/virtual_private_cloud/create_network_parameters.go
+++ b/stackpath/api/ipam/ipam_client/virtual_private_cloud/create_network_parameters.go
@@ -15,7 +15,7 @@ import (
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_models"
 )
 
 // NewCreateNetworkParams creates a new CreateNetworkParams object,
@@ -54,10 +54,12 @@ func NewCreateNetworkParamsWithHTTPClient(client *http.Client) *CreateNetworkPar
 	}
 }
 
-/* CreateNetworkParams contains all the parameters to send to the API endpoint
-   for the create network operation.
+/*
+CreateNetworkParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the create network operation.
+
+	Typically these are written to a http.Request.
 */
 type CreateNetworkParams struct {
 

--- a/stackpath/api/ipam/ipam_client/virtual_private_cloud/create_network_responses.go
+++ b/stackpath/api/ipam/ipam_client/virtual_private_cloud/create_network_responses.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_models"
 )
 
 // CreateNetworkReader is a Reader for the CreateNetwork structure.
@@ -58,7 +58,8 @@ func NewCreateNetworkOK() *CreateNetworkOK {
 	return &CreateNetworkOK{}
 }
 
-/* CreateNetworkOK describes a response with status code 200, with default header values.
+/*
+	CreateNetworkOK describes a response with status code 200, with default header values.
 
 CreateNetworkOK create network o k
 */
@@ -90,7 +91,8 @@ func NewCreateNetworkUnauthorized() *CreateNetworkUnauthorized {
 	return &CreateNetworkUnauthorized{}
 }
 
-/* CreateNetworkUnauthorized describes a response with status code 401, with default header values.
+/*
+	CreateNetworkUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -122,7 +124,8 @@ func NewCreateNetworkInternalServerError() *CreateNetworkInternalServerError {
 	return &CreateNetworkInternalServerError{}
 }
 
-/* CreateNetworkInternalServerError describes a response with status code 500, with default header values.
+/*
+	CreateNetworkInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -156,7 +159,8 @@ func NewCreateNetworkDefault(code int) *CreateNetworkDefault {
 	}
 }
 
-/* CreateNetworkDefault describes a response with status code -1, with default header values.
+/*
+	CreateNetworkDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/ipam/ipam_client/virtual_private_cloud/create_network_subnet_parameters.go
+++ b/stackpath/api/ipam/ipam_client/virtual_private_cloud/create_network_subnet_parameters.go
@@ -15,7 +15,7 @@ import (
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_models"
 )
 
 // NewCreateNetworkSubnetParams creates a new CreateNetworkSubnetParams object,
@@ -54,10 +54,12 @@ func NewCreateNetworkSubnetParamsWithHTTPClient(client *http.Client) *CreateNetw
 	}
 }
 
-/* CreateNetworkSubnetParams contains all the parameters to send to the API endpoint
-   for the create network subnet operation.
+/*
+CreateNetworkSubnetParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the create network subnet operation.
+
+	Typically these are written to a http.Request.
 */
 type CreateNetworkSubnetParams struct {
 

--- a/stackpath/api/ipam/ipam_client/virtual_private_cloud/create_network_subnet_responses.go
+++ b/stackpath/api/ipam/ipam_client/virtual_private_cloud/create_network_subnet_responses.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_models"
 )
 
 // CreateNetworkSubnetReader is a Reader for the CreateNetworkSubnet structure.
@@ -58,7 +58,8 @@ func NewCreateNetworkSubnetOK() *CreateNetworkSubnetOK {
 	return &CreateNetworkSubnetOK{}
 }
 
-/* CreateNetworkSubnetOK describes a response with status code 200, with default header values.
+/*
+	CreateNetworkSubnetOK describes a response with status code 200, with default header values.
 
 CreateNetworkSubnetOK create network subnet o k
 */
@@ -90,7 +91,8 @@ func NewCreateNetworkSubnetUnauthorized() *CreateNetworkSubnetUnauthorized {
 	return &CreateNetworkSubnetUnauthorized{}
 }
 
-/* CreateNetworkSubnetUnauthorized describes a response with status code 401, with default header values.
+/*
+	CreateNetworkSubnetUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -122,7 +124,8 @@ func NewCreateNetworkSubnetInternalServerError() *CreateNetworkSubnetInternalSer
 	return &CreateNetworkSubnetInternalServerError{}
 }
 
-/* CreateNetworkSubnetInternalServerError describes a response with status code 500, with default header values.
+/*
+	CreateNetworkSubnetInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -156,7 +159,8 @@ func NewCreateNetworkSubnetDefault(code int) *CreateNetworkSubnetDefault {
 	}
 }
 
-/* CreateNetworkSubnetDefault describes a response with status code -1, with default header values.
+/*
+	CreateNetworkSubnetDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/ipam/ipam_client/virtual_private_cloud/create_route_parameters.go
+++ b/stackpath/api/ipam/ipam_client/virtual_private_cloud/create_route_parameters.go
@@ -15,7 +15,7 @@ import (
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_models"
 )
 
 // NewCreateRouteParams creates a new CreateRouteParams object,
@@ -54,10 +54,12 @@ func NewCreateRouteParamsWithHTTPClient(client *http.Client) *CreateRouteParams 
 	}
 }
 
-/* CreateRouteParams contains all the parameters to send to the API endpoint
-   for the create route operation.
+/*
+CreateRouteParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the create route operation.
+
+	Typically these are written to a http.Request.
 */
 type CreateRouteParams struct {
 

--- a/stackpath/api/ipam/ipam_client/virtual_private_cloud/create_route_responses.go
+++ b/stackpath/api/ipam/ipam_client/virtual_private_cloud/create_route_responses.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_models"
 )
 
 // CreateRouteReader is a Reader for the CreateRoute structure.
@@ -58,7 +58,8 @@ func NewCreateRouteOK() *CreateRouteOK {
 	return &CreateRouteOK{}
 }
 
-/* CreateRouteOK describes a response with status code 200, with default header values.
+/*
+	CreateRouteOK describes a response with status code 200, with default header values.
 
 CreateRouteOK create route o k
 */
@@ -90,7 +91,8 @@ func NewCreateRouteUnauthorized() *CreateRouteUnauthorized {
 	return &CreateRouteUnauthorized{}
 }
 
-/* CreateRouteUnauthorized describes a response with status code 401, with default header values.
+/*
+	CreateRouteUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -122,7 +124,8 @@ func NewCreateRouteInternalServerError() *CreateRouteInternalServerError {
 	return &CreateRouteInternalServerError{}
 }
 
-/* CreateRouteInternalServerError describes a response with status code 500, with default header values.
+/*
+	CreateRouteInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -156,7 +159,8 @@ func NewCreateRouteDefault(code int) *CreateRouteDefault {
 	}
 }
 
-/* CreateRouteDefault describes a response with status code -1, with default header values.
+/*
+	CreateRouteDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/ipam/ipam_client/virtual_private_cloud/delete_network_responses.go
+++ b/stackpath/api/ipam/ipam_client/virtual_private_cloud/delete_network_responses.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_models"
 )
 
 // DeleteNetworkReader is a Reader for the DeleteNetwork structure.
@@ -58,7 +58,8 @@ func NewDeleteNetworkNoContent() *DeleteNetworkNoContent {
 	return &DeleteNetworkNoContent{}
 }
 
-/* DeleteNetworkNoContent describes a response with status code 204, with default header values.
+/*
+	DeleteNetworkNoContent describes a response with status code 204, with default header values.
 
 No content
 */
@@ -79,7 +80,8 @@ func NewDeleteNetworkUnauthorized() *DeleteNetworkUnauthorized {
 	return &DeleteNetworkUnauthorized{}
 }
 
-/* DeleteNetworkUnauthorized describes a response with status code 401, with default header values.
+/*
+	DeleteNetworkUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -111,7 +113,8 @@ func NewDeleteNetworkInternalServerError() *DeleteNetworkInternalServerError {
 	return &DeleteNetworkInternalServerError{}
 }
 
-/* DeleteNetworkInternalServerError describes a response with status code 500, with default header values.
+/*
+	DeleteNetworkInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -145,7 +148,8 @@ func NewDeleteNetworkDefault(code int) *DeleteNetworkDefault {
 	}
 }
 
-/* DeleteNetworkDefault describes a response with status code -1, with default header values.
+/*
+	DeleteNetworkDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/ipam/ipam_client/virtual_private_cloud/delete_network_subnet_responses.go
+++ b/stackpath/api/ipam/ipam_client/virtual_private_cloud/delete_network_subnet_responses.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_models"
 )
 
 // DeleteNetworkSubnetReader is a Reader for the DeleteNetworkSubnet structure.
@@ -58,7 +58,8 @@ func NewDeleteNetworkSubnetNoContent() *DeleteNetworkSubnetNoContent {
 	return &DeleteNetworkSubnetNoContent{}
 }
 
-/* DeleteNetworkSubnetNoContent describes a response with status code 204, with default header values.
+/*
+	DeleteNetworkSubnetNoContent describes a response with status code 204, with default header values.
 
 No content
 */
@@ -79,7 +80,8 @@ func NewDeleteNetworkSubnetUnauthorized() *DeleteNetworkSubnetUnauthorized {
 	return &DeleteNetworkSubnetUnauthorized{}
 }
 
-/* DeleteNetworkSubnetUnauthorized describes a response with status code 401, with default header values.
+/*
+	DeleteNetworkSubnetUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -111,7 +113,8 @@ func NewDeleteNetworkSubnetInternalServerError() *DeleteNetworkSubnetInternalSer
 	return &DeleteNetworkSubnetInternalServerError{}
 }
 
-/* DeleteNetworkSubnetInternalServerError describes a response with status code 500, with default header values.
+/*
+	DeleteNetworkSubnetInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -145,7 +148,8 @@ func NewDeleteNetworkSubnetDefault(code int) *DeleteNetworkSubnetDefault {
 	}
 }
 
-/* DeleteNetworkSubnetDefault describes a response with status code -1, with default header values.
+/*
+	DeleteNetworkSubnetDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/ipam/ipam_client/virtual_private_cloud/delete_route_responses.go
+++ b/stackpath/api/ipam/ipam_client/virtual_private_cloud/delete_route_responses.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_models"
 )
 
 // DeleteRouteReader is a Reader for the DeleteRoute structure.
@@ -58,7 +58,8 @@ func NewDeleteRouteNoContent() *DeleteRouteNoContent {
 	return &DeleteRouteNoContent{}
 }
 
-/* DeleteRouteNoContent describes a response with status code 204, with default header values.
+/*
+	DeleteRouteNoContent describes a response with status code 204, with default header values.
 
 No content
 */
@@ -79,7 +80,8 @@ func NewDeleteRouteUnauthorized() *DeleteRouteUnauthorized {
 	return &DeleteRouteUnauthorized{}
 }
 
-/* DeleteRouteUnauthorized describes a response with status code 401, with default header values.
+/*
+	DeleteRouteUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -111,7 +113,8 @@ func NewDeleteRouteInternalServerError() *DeleteRouteInternalServerError {
 	return &DeleteRouteInternalServerError{}
 }
 
-/* DeleteRouteInternalServerError describes a response with status code 500, with default header values.
+/*
+	DeleteRouteInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -145,7 +148,8 @@ func NewDeleteRouteDefault(code int) *DeleteRouteDefault {
 	}
 }
 
-/* DeleteRouteDefault describes a response with status code -1, with default header values.
+/*
+	DeleteRouteDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/ipam/ipam_client/virtual_private_cloud/get_network_responses.go
+++ b/stackpath/api/ipam/ipam_client/virtual_private_cloud/get_network_responses.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_models"
 )
 
 // GetNetworkReader is a Reader for the GetNetwork structure.
@@ -58,7 +58,8 @@ func NewGetNetworkOK() *GetNetworkOK {
 	return &GetNetworkOK{}
 }
 
-/* GetNetworkOK describes a response with status code 200, with default header values.
+/*
+	GetNetworkOK describes a response with status code 200, with default header values.
 
 GetNetworkOK get network o k
 */
@@ -90,7 +91,8 @@ func NewGetNetworkUnauthorized() *GetNetworkUnauthorized {
 	return &GetNetworkUnauthorized{}
 }
 
-/* GetNetworkUnauthorized describes a response with status code 401, with default header values.
+/*
+	GetNetworkUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -122,7 +124,8 @@ func NewGetNetworkInternalServerError() *GetNetworkInternalServerError {
 	return &GetNetworkInternalServerError{}
 }
 
-/* GetNetworkInternalServerError describes a response with status code 500, with default header values.
+/*
+	GetNetworkInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -156,7 +159,8 @@ func NewGetNetworkDefault(code int) *GetNetworkDefault {
 	}
 }
 
-/* GetNetworkDefault describes a response with status code -1, with default header values.
+/*
+	GetNetworkDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/ipam/ipam_client/virtual_private_cloud/get_network_subnet_responses.go
+++ b/stackpath/api/ipam/ipam_client/virtual_private_cloud/get_network_subnet_responses.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_models"
 )
 
 // GetNetworkSubnetReader is a Reader for the GetNetworkSubnet structure.
@@ -58,7 +58,8 @@ func NewGetNetworkSubnetOK() *GetNetworkSubnetOK {
 	return &GetNetworkSubnetOK{}
 }
 
-/* GetNetworkSubnetOK describes a response with status code 200, with default header values.
+/*
+	GetNetworkSubnetOK describes a response with status code 200, with default header values.
 
 GetNetworkSubnetOK get network subnet o k
 */
@@ -90,7 +91,8 @@ func NewGetNetworkSubnetUnauthorized() *GetNetworkSubnetUnauthorized {
 	return &GetNetworkSubnetUnauthorized{}
 }
 
-/* GetNetworkSubnetUnauthorized describes a response with status code 401, with default header values.
+/*
+	GetNetworkSubnetUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -122,7 +124,8 @@ func NewGetNetworkSubnetInternalServerError() *GetNetworkSubnetInternalServerErr
 	return &GetNetworkSubnetInternalServerError{}
 }
 
-/* GetNetworkSubnetInternalServerError describes a response with status code 500, with default header values.
+/*
+	GetNetworkSubnetInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -156,7 +159,8 @@ func NewGetNetworkSubnetDefault(code int) *GetNetworkSubnetDefault {
 	}
 }
 
-/* GetNetworkSubnetDefault describes a response with status code -1, with default header values.
+/*
+	GetNetworkSubnetDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/ipam/ipam_client/virtual_private_cloud/get_network_subnets_responses.go
+++ b/stackpath/api/ipam/ipam_client/virtual_private_cloud/get_network_subnets_responses.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_models"
 )
 
 // GetNetworkSubnetsReader is a Reader for the GetNetworkSubnets structure.
@@ -58,7 +58,8 @@ func NewGetNetworkSubnetsOK() *GetNetworkSubnetsOK {
 	return &GetNetworkSubnetsOK{}
 }
 
-/* GetNetworkSubnetsOK describes a response with status code 200, with default header values.
+/*
+	GetNetworkSubnetsOK describes a response with status code 200, with default header values.
 
 GetNetworkSubnetsOK get network subnets o k
 */
@@ -90,7 +91,8 @@ func NewGetNetworkSubnetsUnauthorized() *GetNetworkSubnetsUnauthorized {
 	return &GetNetworkSubnetsUnauthorized{}
 }
 
-/* GetNetworkSubnetsUnauthorized describes a response with status code 401, with default header values.
+/*
+	GetNetworkSubnetsUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -122,7 +124,8 @@ func NewGetNetworkSubnetsInternalServerError() *GetNetworkSubnetsInternalServerE
 	return &GetNetworkSubnetsInternalServerError{}
 }
 
-/* GetNetworkSubnetsInternalServerError describes a response with status code 500, with default header values.
+/*
+	GetNetworkSubnetsInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -156,7 +159,8 @@ func NewGetNetworkSubnetsDefault(code int) *GetNetworkSubnetsDefault {
 	}
 }
 
-/* GetNetworkSubnetsDefault describes a response with status code -1, with default header values.
+/*
+	GetNetworkSubnetsDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/ipam/ipam_client/virtual_private_cloud/get_networks_responses.go
+++ b/stackpath/api/ipam/ipam_client/virtual_private_cloud/get_networks_responses.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_models"
 )
 
 // GetNetworksReader is a Reader for the GetNetworks structure.
@@ -58,7 +58,8 @@ func NewGetNetworksOK() *GetNetworksOK {
 	return &GetNetworksOK{}
 }
 
-/* GetNetworksOK describes a response with status code 200, with default header values.
+/*
+	GetNetworksOK describes a response with status code 200, with default header values.
 
 GetNetworksOK get networks o k
 */
@@ -90,7 +91,8 @@ func NewGetNetworksUnauthorized() *GetNetworksUnauthorized {
 	return &GetNetworksUnauthorized{}
 }
 
-/* GetNetworksUnauthorized describes a response with status code 401, with default header values.
+/*
+	GetNetworksUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -122,7 +124,8 @@ func NewGetNetworksInternalServerError() *GetNetworksInternalServerError {
 	return &GetNetworksInternalServerError{}
 }
 
-/* GetNetworksInternalServerError describes a response with status code 500, with default header values.
+/*
+	GetNetworksInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -156,7 +159,8 @@ func NewGetNetworksDefault(code int) *GetNetworksDefault {
 	}
 }
 
-/* GetNetworksDefault describes a response with status code -1, with default header values.
+/*
+	GetNetworksDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/ipam/ipam_client/virtual_private_cloud/get_route_responses.go
+++ b/stackpath/api/ipam/ipam_client/virtual_private_cloud/get_route_responses.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_models"
 )
 
 // GetRouteReader is a Reader for the GetRoute structure.
@@ -58,7 +58,8 @@ func NewGetRouteOK() *GetRouteOK {
 	return &GetRouteOK{}
 }
 
-/* GetRouteOK describes a response with status code 200, with default header values.
+/*
+	GetRouteOK describes a response with status code 200, with default header values.
 
 GetRouteOK get route o k
 */
@@ -90,7 +91,8 @@ func NewGetRouteUnauthorized() *GetRouteUnauthorized {
 	return &GetRouteUnauthorized{}
 }
 
-/* GetRouteUnauthorized describes a response with status code 401, with default header values.
+/*
+	GetRouteUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -122,7 +124,8 @@ func NewGetRouteInternalServerError() *GetRouteInternalServerError {
 	return &GetRouteInternalServerError{}
 }
 
-/* GetRouteInternalServerError describes a response with status code 500, with default header values.
+/*
+	GetRouteInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -156,7 +159,8 @@ func NewGetRouteDefault(code int) *GetRouteDefault {
 	}
 }
 
-/* GetRouteDefault describes a response with status code -1, with default header values.
+/*
+	GetRouteDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/ipam/ipam_client/virtual_private_cloud/get_routes_responses.go
+++ b/stackpath/api/ipam/ipam_client/virtual_private_cloud/get_routes_responses.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_models"
 )
 
 // GetRoutesReader is a Reader for the GetRoutes structure.
@@ -58,7 +58,8 @@ func NewGetRoutesOK() *GetRoutesOK {
 	return &GetRoutesOK{}
 }
 
-/* GetRoutesOK describes a response with status code 200, with default header values.
+/*
+	GetRoutesOK describes a response with status code 200, with default header values.
 
 GetRoutesOK get routes o k
 */
@@ -90,7 +91,8 @@ func NewGetRoutesUnauthorized() *GetRoutesUnauthorized {
 	return &GetRoutesUnauthorized{}
 }
 
-/* GetRoutesUnauthorized describes a response with status code 401, with default header values.
+/*
+	GetRoutesUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -122,7 +124,8 @@ func NewGetRoutesInternalServerError() *GetRoutesInternalServerError {
 	return &GetRoutesInternalServerError{}
 }
 
-/* GetRoutesInternalServerError describes a response with status code 500, with default header values.
+/*
+	GetRoutesInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -156,7 +159,8 @@ func NewGetRoutesDefault(code int) *GetRoutesDefault {
 	}
 }
 
-/* GetRoutesDefault describes a response with status code -1, with default header values.
+/*
+	GetRoutesDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/ipam/ipam_client/virtual_private_cloud/update_network_parameters.go
+++ b/stackpath/api/ipam/ipam_client/virtual_private_cloud/update_network_parameters.go
@@ -15,7 +15,7 @@ import (
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_models"
 )
 
 // NewUpdateNetworkParams creates a new UpdateNetworkParams object,
@@ -54,10 +54,12 @@ func NewUpdateNetworkParamsWithHTTPClient(client *http.Client) *UpdateNetworkPar
 	}
 }
 
-/* UpdateNetworkParams contains all the parameters to send to the API endpoint
-   for the update network operation.
+/*
+UpdateNetworkParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the update network operation.
+
+	Typically these are written to a http.Request.
 */
 type UpdateNetworkParams struct {
 

--- a/stackpath/api/ipam/ipam_client/virtual_private_cloud/update_network_responses.go
+++ b/stackpath/api/ipam/ipam_client/virtual_private_cloud/update_network_responses.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_models"
 )
 
 // UpdateNetworkReader is a Reader for the UpdateNetwork structure.
@@ -58,7 +58,8 @@ func NewUpdateNetworkOK() *UpdateNetworkOK {
 	return &UpdateNetworkOK{}
 }
 
-/* UpdateNetworkOK describes a response with status code 200, with default header values.
+/*
+	UpdateNetworkOK describes a response with status code 200, with default header values.
 
 UpdateNetworkOK update network o k
 */
@@ -90,7 +91,8 @@ func NewUpdateNetworkUnauthorized() *UpdateNetworkUnauthorized {
 	return &UpdateNetworkUnauthorized{}
 }
 
-/* UpdateNetworkUnauthorized describes a response with status code 401, with default header values.
+/*
+	UpdateNetworkUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -122,7 +124,8 @@ func NewUpdateNetworkInternalServerError() *UpdateNetworkInternalServerError {
 	return &UpdateNetworkInternalServerError{}
 }
 
-/* UpdateNetworkInternalServerError describes a response with status code 500, with default header values.
+/*
+	UpdateNetworkInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -156,7 +159,8 @@ func NewUpdateNetworkDefault(code int) *UpdateNetworkDefault {
 	}
 }
 
-/* UpdateNetworkDefault describes a response with status code -1, with default header values.
+/*
+	UpdateNetworkDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/ipam/ipam_client/virtual_private_cloud/update_network_subnet_parameters.go
+++ b/stackpath/api/ipam/ipam_client/virtual_private_cloud/update_network_subnet_parameters.go
@@ -15,7 +15,7 @@ import (
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_models"
 )
 
 // NewUpdateNetworkSubnetParams creates a new UpdateNetworkSubnetParams object,
@@ -54,10 +54,12 @@ func NewUpdateNetworkSubnetParamsWithHTTPClient(client *http.Client) *UpdateNetw
 	}
 }
 
-/* UpdateNetworkSubnetParams contains all the parameters to send to the API endpoint
-   for the update network subnet operation.
+/*
+UpdateNetworkSubnetParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the update network subnet operation.
+
+	Typically these are written to a http.Request.
 */
 type UpdateNetworkSubnetParams struct {
 

--- a/stackpath/api/ipam/ipam_client/virtual_private_cloud/update_network_subnet_responses.go
+++ b/stackpath/api/ipam/ipam_client/virtual_private_cloud/update_network_subnet_responses.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_models"
 )
 
 // UpdateNetworkSubnetReader is a Reader for the UpdateNetworkSubnet structure.
@@ -58,7 +58,8 @@ func NewUpdateNetworkSubnetOK() *UpdateNetworkSubnetOK {
 	return &UpdateNetworkSubnetOK{}
 }
 
-/* UpdateNetworkSubnetOK describes a response with status code 200, with default header values.
+/*
+	UpdateNetworkSubnetOK describes a response with status code 200, with default header values.
 
 UpdateNetworkSubnetOK update network subnet o k
 */
@@ -90,7 +91,8 @@ func NewUpdateNetworkSubnetUnauthorized() *UpdateNetworkSubnetUnauthorized {
 	return &UpdateNetworkSubnetUnauthorized{}
 }
 
-/* UpdateNetworkSubnetUnauthorized describes a response with status code 401, with default header values.
+/*
+	UpdateNetworkSubnetUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -122,7 +124,8 @@ func NewUpdateNetworkSubnetInternalServerError() *UpdateNetworkSubnetInternalSer
 	return &UpdateNetworkSubnetInternalServerError{}
 }
 
-/* UpdateNetworkSubnetInternalServerError describes a response with status code 500, with default header values.
+/*
+	UpdateNetworkSubnetInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -156,7 +159,8 @@ func NewUpdateNetworkSubnetDefault(code int) *UpdateNetworkSubnetDefault {
 	}
 }
 
-/* UpdateNetworkSubnetDefault describes a response with status code -1, with default header values.
+/*
+	UpdateNetworkSubnetDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/ipam/ipam_client/virtual_private_cloud/update_route_parameters.go
+++ b/stackpath/api/ipam/ipam_client/virtual_private_cloud/update_route_parameters.go
@@ -15,7 +15,7 @@ import (
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_models"
 )
 
 // NewUpdateRouteParams creates a new UpdateRouteParams object,
@@ -54,10 +54,12 @@ func NewUpdateRouteParamsWithHTTPClient(client *http.Client) *UpdateRouteParams 
 	}
 }
 
-/* UpdateRouteParams contains all the parameters to send to the API endpoint
-   for the update route operation.
+/*
+UpdateRouteParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the update route operation.
+
+	Typically these are written to a http.Request.
 */
 type UpdateRouteParams struct {
 

--- a/stackpath/api/ipam/ipam_client/virtual_private_cloud/update_route_responses.go
+++ b/stackpath/api/ipam/ipam_client/virtual_private_cloud/update_route_responses.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_models"
 )
 
 // UpdateRouteReader is a Reader for the UpdateRoute structure.
@@ -58,7 +58,8 @@ func NewUpdateRouteOK() *UpdateRouteOK {
 	return &UpdateRouteOK{}
 }
 
-/* UpdateRouteOK describes a response with status code 200, with default header values.
+/*
+	UpdateRouteOK describes a response with status code 200, with default header values.
 
 UpdateRouteOK update route o k
 */
@@ -90,7 +91,8 @@ func NewUpdateRouteUnauthorized() *UpdateRouteUnauthorized {
 	return &UpdateRouteUnauthorized{}
 }
 
-/* UpdateRouteUnauthorized describes a response with status code 401, with default header values.
+/*
+	UpdateRouteUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -122,7 +124,8 @@ func NewUpdateRouteInternalServerError() *UpdateRouteInternalServerError {
 	return &UpdateRouteInternalServerError{}
 }
 
-/* UpdateRouteInternalServerError describes a response with status code 500, with default header values.
+/*
+	UpdateRouteInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -156,7 +159,8 @@ func NewUpdateRouteDefault(code int) *UpdateRouteDefault {
 	}
 }
 
-/* UpdateRouteDefault describes a response with status code -1, with default header values.
+/*
+	UpdateRouteDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/storage/storage_client/buckets/create_bucket_parameters.go
+++ b/stackpath/api/storage/storage_client/buckets/create_bucket_parameters.go
@@ -15,7 +15,7 @@ import (
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/storage/storage_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/storage/storage_models"
 )
 
 // NewCreateBucketParams creates a new CreateBucketParams object,
@@ -54,10 +54,12 @@ func NewCreateBucketParamsWithHTTPClient(client *http.Client) *CreateBucketParam
 	}
 }
 
-/* CreateBucketParams contains all the parameters to send to the API endpoint
-   for the create bucket operation.
+/*
+CreateBucketParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the create bucket operation.
+
+	Typically these are written to a http.Request.
 */
 type CreateBucketParams struct {
 

--- a/stackpath/api/storage/storage_client/buckets/create_bucket_responses.go
+++ b/stackpath/api/storage/storage_client/buckets/create_bucket_responses.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/storage/storage_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/storage/storage_models"
 )
 
 // CreateBucketReader is a Reader for the CreateBucket structure.
@@ -58,7 +58,8 @@ func NewCreateBucketOK() *CreateBucketOK {
 	return &CreateBucketOK{}
 }
 
-/* CreateBucketOK describes a response with status code 200, with default header values.
+/*
+	CreateBucketOK describes a response with status code 200, with default header values.
 
 CreateBucketOK create bucket o k
 */
@@ -90,7 +91,8 @@ func NewCreateBucketUnauthorized() *CreateBucketUnauthorized {
 	return &CreateBucketUnauthorized{}
 }
 
-/* CreateBucketUnauthorized describes a response with status code 401, with default header values.
+/*
+	CreateBucketUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -122,7 +124,8 @@ func NewCreateBucketInternalServerError() *CreateBucketInternalServerError {
 	return &CreateBucketInternalServerError{}
 }
 
-/* CreateBucketInternalServerError describes a response with status code 500, with default header values.
+/*
+	CreateBucketInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -156,7 +159,8 @@ func NewCreateBucketDefault(code int) *CreateBucketDefault {
 	}
 }
 
-/* CreateBucketDefault describes a response with status code -1, with default header values.
+/*
+	CreateBucketDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/storage/storage_client/buckets/delete_bucket_responses.go
+++ b/stackpath/api/storage/storage_client/buckets/delete_bucket_responses.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/storage/storage_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/storage/storage_models"
 )
 
 // DeleteBucketReader is a Reader for the DeleteBucket structure.
@@ -58,7 +58,8 @@ func NewDeleteBucketNoContent() *DeleteBucketNoContent {
 	return &DeleteBucketNoContent{}
 }
 
-/* DeleteBucketNoContent describes a response with status code 204, with default header values.
+/*
+	DeleteBucketNoContent describes a response with status code 204, with default header values.
 
 No content
 */
@@ -79,7 +80,8 @@ func NewDeleteBucketUnauthorized() *DeleteBucketUnauthorized {
 	return &DeleteBucketUnauthorized{}
 }
 
-/* DeleteBucketUnauthorized describes a response with status code 401, with default header values.
+/*
+	DeleteBucketUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -111,7 +113,8 @@ func NewDeleteBucketInternalServerError() *DeleteBucketInternalServerError {
 	return &DeleteBucketInternalServerError{}
 }
 
-/* DeleteBucketInternalServerError describes a response with status code 500, with default header values.
+/*
+	DeleteBucketInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -145,7 +148,8 @@ func NewDeleteBucketDefault(code int) *DeleteBucketDefault {
 	}
 }
 
-/* DeleteBucketDefault describes a response with status code -1, with default header values.
+/*
+	DeleteBucketDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/storage/storage_client/buckets/get_bucket_responses.go
+++ b/stackpath/api/storage/storage_client/buckets/get_bucket_responses.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/storage/storage_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/storage/storage_models"
 )
 
 // GetBucketReader is a Reader for the GetBucket structure.
@@ -58,7 +58,8 @@ func NewGetBucketOK() *GetBucketOK {
 	return &GetBucketOK{}
 }
 
-/* GetBucketOK describes a response with status code 200, with default header values.
+/*
+	GetBucketOK describes a response with status code 200, with default header values.
 
 GetBucketOK get bucket o k
 */
@@ -90,7 +91,8 @@ func NewGetBucketUnauthorized() *GetBucketUnauthorized {
 	return &GetBucketUnauthorized{}
 }
 
-/* GetBucketUnauthorized describes a response with status code 401, with default header values.
+/*
+	GetBucketUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -122,7 +124,8 @@ func NewGetBucketInternalServerError() *GetBucketInternalServerError {
 	return &GetBucketInternalServerError{}
 }
 
-/* GetBucketInternalServerError describes a response with status code 500, with default header values.
+/*
+	GetBucketInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -156,7 +159,8 @@ func NewGetBucketDefault(code int) *GetBucketDefault {
 	}
 }
 
-/* GetBucketDefault describes a response with status code -1, with default header values.
+/*
+	GetBucketDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/storage/storage_client/buckets/get_buckets_responses.go
+++ b/stackpath/api/storage/storage_client/buckets/get_buckets_responses.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/storage/storage_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/storage/storage_models"
 )
 
 // GetBucketsReader is a Reader for the GetBuckets structure.
@@ -58,7 +58,8 @@ func NewGetBucketsOK() *GetBucketsOK {
 	return &GetBucketsOK{}
 }
 
-/* GetBucketsOK describes a response with status code 200, with default header values.
+/*
+	GetBucketsOK describes a response with status code 200, with default header values.
 
 GetBucketsOK get buckets o k
 */
@@ -90,7 +91,8 @@ func NewGetBucketsUnauthorized() *GetBucketsUnauthorized {
 	return &GetBucketsUnauthorized{}
 }
 
-/* GetBucketsUnauthorized describes a response with status code 401, with default header values.
+/*
+	GetBucketsUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -122,7 +124,8 @@ func NewGetBucketsInternalServerError() *GetBucketsInternalServerError {
 	return &GetBucketsInternalServerError{}
 }
 
-/* GetBucketsInternalServerError describes a response with status code 500, with default header values.
+/*
+	GetBucketsInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -156,7 +159,8 @@ func NewGetBucketsDefault(code int) *GetBucketsDefault {
 	}
 }
 
-/* GetBucketsDefault describes a response with status code -1, with default header values.
+/*
+	GetBucketsDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/storage/storage_client/buckets/update_bucket_parameters.go
+++ b/stackpath/api/storage/storage_client/buckets/update_bucket_parameters.go
@@ -15,7 +15,7 @@ import (
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/storage/storage_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/storage/storage_models"
 )
 
 // NewUpdateBucketParams creates a new UpdateBucketParams object,
@@ -54,10 +54,12 @@ func NewUpdateBucketParamsWithHTTPClient(client *http.Client) *UpdateBucketParam
 	}
 }
 
-/* UpdateBucketParams contains all the parameters to send to the API endpoint
-   for the update bucket operation.
+/*
+UpdateBucketParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the update bucket operation.
+
+	Typically these are written to a http.Request.
 */
 type UpdateBucketParams struct {
 

--- a/stackpath/api/storage/storage_client/buckets/update_bucket_responses.go
+++ b/stackpath/api/storage/storage_client/buckets/update_bucket_responses.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/storage/storage_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/storage/storage_models"
 )
 
 // UpdateBucketReader is a Reader for the UpdateBucket structure.
@@ -58,7 +58,8 @@ func NewUpdateBucketOK() *UpdateBucketOK {
 	return &UpdateBucketOK{}
 }
 
-/* UpdateBucketOK describes a response with status code 200, with default header values.
+/*
+	UpdateBucketOK describes a response with status code 200, with default header values.
 
 UpdateBucketOK update bucket o k
 */
@@ -90,7 +91,8 @@ func NewUpdateBucketUnauthorized() *UpdateBucketUnauthorized {
 	return &UpdateBucketUnauthorized{}
 }
 
-/* UpdateBucketUnauthorized describes a response with status code 401, with default header values.
+/*
+	UpdateBucketUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -122,7 +124,8 @@ func NewUpdateBucketInternalServerError() *UpdateBucketInternalServerError {
 	return &UpdateBucketInternalServerError{}
 }
 
-/* UpdateBucketInternalServerError describes a response with status code 500, with default header values.
+/*
+	UpdateBucketInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -156,7 +159,8 @@ func NewUpdateBucketDefault(code int) *UpdateBucketDefault {
 	}
 }
 
-/* UpdateBucketDefault describes a response with status code -1, with default header values.
+/*
+	UpdateBucketDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/storage/storage_client/metrics/get_bucket_metrics_responses.go
+++ b/stackpath/api/storage/storage_client/metrics/get_bucket_metrics_responses.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/storage/storage_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/storage/storage_models"
 )
 
 // GetBucketMetricsReader is a Reader for the GetBucketMetrics structure.
@@ -58,7 +58,8 @@ func NewGetBucketMetricsOK() *GetBucketMetricsOK {
 	return &GetBucketMetricsOK{}
 }
 
-/* GetBucketMetricsOK describes a response with status code 200, with default header values.
+/*
+	GetBucketMetricsOK describes a response with status code 200, with default header values.
 
 GetBucketMetricsOK get bucket metrics o k
 */
@@ -90,7 +91,8 @@ func NewGetBucketMetricsUnauthorized() *GetBucketMetricsUnauthorized {
 	return &GetBucketMetricsUnauthorized{}
 }
 
-/* GetBucketMetricsUnauthorized describes a response with status code 401, with default header values.
+/*
+	GetBucketMetricsUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -122,7 +124,8 @@ func NewGetBucketMetricsInternalServerError() *GetBucketMetricsInternalServerErr
 	return &GetBucketMetricsInternalServerError{}
 }
 
-/* GetBucketMetricsInternalServerError describes a response with status code 500, with default header values.
+/*
+	GetBucketMetricsInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -156,7 +159,8 @@ func NewGetBucketMetricsDefault(code int) *GetBucketMetricsDefault {
 	}
 }
 
-/* GetBucketMetricsDefault describes a response with status code -1, with default header values.
+/*
+	GetBucketMetricsDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/storage/storage_client/metrics/get_stack_metrics_responses.go
+++ b/stackpath/api/storage/storage_client/metrics/get_stack_metrics_responses.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/storage/storage_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/storage/storage_models"
 )
 
 // GetStackMetricsReader is a Reader for the GetStackMetrics structure.
@@ -58,7 +58,8 @@ func NewGetStackMetricsOK() *GetStackMetricsOK {
 	return &GetStackMetricsOK{}
 }
 
-/* GetStackMetricsOK describes a response with status code 200, with default header values.
+/*
+	GetStackMetricsOK describes a response with status code 200, with default header values.
 
 GetStackMetricsOK get stack metrics o k
 */
@@ -90,7 +91,8 @@ func NewGetStackMetricsUnauthorized() *GetStackMetricsUnauthorized {
 	return &GetStackMetricsUnauthorized{}
 }
 
-/* GetStackMetricsUnauthorized describes a response with status code 401, with default header values.
+/*
+	GetStackMetricsUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -122,7 +124,8 @@ func NewGetStackMetricsInternalServerError() *GetStackMetricsInternalServerError
 	return &GetStackMetricsInternalServerError{}
 }
 
-/* GetStackMetricsInternalServerError describes a response with status code 500, with default header values.
+/*
+	GetStackMetricsInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -156,7 +159,8 @@ func NewGetStackMetricsDefault(code int) *GetStackMetricsDefault {
 	}
 }
 
-/* GetStackMetricsDefault describes a response with status code -1, with default header values.
+/*
+	GetStackMetricsDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/storage/storage_client/object_storage_client.go
+++ b/stackpath/api/storage/storage_client/object_storage_client.go
@@ -10,9 +10,9 @@ import (
 	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/storage/storage_client/buckets"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/storage/storage_client/metrics"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/storage/storage_client/user_credentials"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/storage/storage_client/buckets"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/storage/storage_client/metrics"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/storage/storage_client/user_credentials"
 )
 
 // Default object storage HTTP client.

--- a/stackpath/api/storage/storage_client/user_credentials/delete_credential_responses.go
+++ b/stackpath/api/storage/storage_client/user_credentials/delete_credential_responses.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/storage/storage_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/storage/storage_models"
 )
 
 // DeleteCredentialReader is a Reader for the DeleteCredential structure.
@@ -58,7 +58,8 @@ func NewDeleteCredentialNoContent() *DeleteCredentialNoContent {
 	return &DeleteCredentialNoContent{}
 }
 
-/* DeleteCredentialNoContent describes a response with status code 204, with default header values.
+/*
+	DeleteCredentialNoContent describes a response with status code 204, with default header values.
 
 No content
 */
@@ -79,7 +80,8 @@ func NewDeleteCredentialUnauthorized() *DeleteCredentialUnauthorized {
 	return &DeleteCredentialUnauthorized{}
 }
 
-/* DeleteCredentialUnauthorized describes a response with status code 401, with default header values.
+/*
+	DeleteCredentialUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -111,7 +113,8 @@ func NewDeleteCredentialInternalServerError() *DeleteCredentialInternalServerErr
 	return &DeleteCredentialInternalServerError{}
 }
 
-/* DeleteCredentialInternalServerError describes a response with status code 500, with default header values.
+/*
+	DeleteCredentialInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -145,7 +148,8 @@ func NewDeleteCredentialDefault(code int) *DeleteCredentialDefault {
 	}
 }
 
-/* DeleteCredentialDefault describes a response with status code -1, with default header values.
+/*
+	DeleteCredentialDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/storage/storage_client/user_credentials/generate_credentials_responses.go
+++ b/stackpath/api/storage/storage_client/user_credentials/generate_credentials_responses.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/storage/storage_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/storage/storage_models"
 )
 
 // GenerateCredentialsReader is a Reader for the GenerateCredentials structure.
@@ -58,7 +58,8 @@ func NewGenerateCredentialsOK() *GenerateCredentialsOK {
 	return &GenerateCredentialsOK{}
 }
 
-/* GenerateCredentialsOK describes a response with status code 200, with default header values.
+/*
+	GenerateCredentialsOK describes a response with status code 200, with default header values.
 
 GenerateCredentialsOK generate credentials o k
 */
@@ -90,7 +91,8 @@ func NewGenerateCredentialsUnauthorized() *GenerateCredentialsUnauthorized {
 	return &GenerateCredentialsUnauthorized{}
 }
 
-/* GenerateCredentialsUnauthorized describes a response with status code 401, with default header values.
+/*
+	GenerateCredentialsUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -122,7 +124,8 @@ func NewGenerateCredentialsInternalServerError() *GenerateCredentialsInternalSer
 	return &GenerateCredentialsInternalServerError{}
 }
 
-/* GenerateCredentialsInternalServerError describes a response with status code 500, with default header values.
+/*
+	GenerateCredentialsInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -156,7 +159,8 @@ func NewGenerateCredentialsDefault(code int) *GenerateCredentialsDefault {
 	}
 }
 
-/* GenerateCredentialsDefault describes a response with status code -1, with default header values.
+/*
+	GenerateCredentialsDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/storage/storage_client/user_credentials/get_credentials_responses.go
+++ b/stackpath/api/storage/storage_client/user_credentials/get_credentials_responses.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/storage/storage_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/storage/storage_models"
 )
 
 // GetCredentialsReader is a Reader for the GetCredentials structure.
@@ -58,7 +58,8 @@ func NewGetCredentialsOK() *GetCredentialsOK {
 	return &GetCredentialsOK{}
 }
 
-/* GetCredentialsOK describes a response with status code 200, with default header values.
+/*
+	GetCredentialsOK describes a response with status code 200, with default header values.
 
 GetCredentialsOK get credentials o k
 */
@@ -90,7 +91,8 @@ func NewGetCredentialsUnauthorized() *GetCredentialsUnauthorized {
 	return &GetCredentialsUnauthorized{}
 }
 
-/* GetCredentialsUnauthorized describes a response with status code 401, with default header values.
+/*
+	GetCredentialsUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -122,7 +124,8 @@ func NewGetCredentialsInternalServerError() *GetCredentialsInternalServerError {
 	return &GetCredentialsInternalServerError{}
 }
 
-/* GetCredentialsInternalServerError describes a response with status code 500, with default header values.
+/*
+	GetCredentialsInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -156,7 +159,8 @@ func NewGetCredentialsDefault(code int) *GetCredentialsDefault {
 	}
 }
 
-/* GetCredentialsDefault describes a response with status code -1, with default header values.
+/*
+	GetCredentialsDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/workload/workload_client/edge_compute_client.go
+++ b/stackpath/api/workload/workload_client/edge_compute_client.go
@@ -10,13 +10,13 @@ import (
 	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/workload/workload_client/infrastructure"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/workload/workload_client/instance"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/workload/workload_client/instance_logs"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/workload/workload_client/instances"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/workload/workload_client/metrics"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/workload/workload_client/virtual_machine_images"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/workload/workload_client/workloads"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/workload/workload_client/infrastructure"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/workload/workload_client/instance"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/workload/workload_client/instance_logs"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/workload/workload_client/instances"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/workload/workload_client/metrics"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/workload/workload_client/virtual_machine_images"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/workload/workload_client/workloads"
 )
 
 // Default edge compute HTTP client.

--- a/stackpath/api/workload/workload_client/infrastructure/get_locations_responses.go
+++ b/stackpath/api/workload/workload_client/infrastructure/get_locations_responses.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/workload/workload_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/workload/workload_models"
 )
 
 // GetLocationsReader is a Reader for the GetLocations structure.

--- a/stackpath/api/workload/workload_client/instance/get_workload_instance_initial_password_responses.go
+++ b/stackpath/api/workload/workload_client/instance/get_workload_instance_initial_password_responses.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/workload/workload_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/workload/workload_models"
 )
 
 // GetWorkloadInstanceInitialPasswordReader is a Reader for the GetWorkloadInstanceInitialPassword structure.

--- a/stackpath/api/workload/workload_client/instance_logs/get_logs_responses.go
+++ b/stackpath/api/workload/workload_client/instance_logs/get_logs_responses.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/workload/workload_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/workload/workload_models"
 )
 
 // GetLogsReader is a Reader for the GetLogs structure.

--- a/stackpath/api/workload/workload_client/instances/get_workload_instance_responses.go
+++ b/stackpath/api/workload/workload_client/instances/get_workload_instance_responses.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/workload/workload_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/workload/workload_models"
 )
 
 // GetWorkloadInstanceReader is a Reader for the GetWorkloadInstance structure.

--- a/stackpath/api/workload/workload_client/instances/get_workload_instances_responses.go
+++ b/stackpath/api/workload/workload_client/instances/get_workload_instances_responses.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/workload/workload_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/workload/workload_models"
 )
 
 // GetWorkloadInstancesReader is a Reader for the GetWorkloadInstances structure.

--- a/stackpath/api/workload/workload_client/instances/restart_instance_responses.go
+++ b/stackpath/api/workload/workload_client/instances/restart_instance_responses.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/workload/workload_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/workload/workload_models"
 )
 
 // RestartInstanceReader is a Reader for the RestartInstance structure.

--- a/stackpath/api/workload/workload_client/metrics/get_metrics_responses.go
+++ b/stackpath/api/workload/workload_client/metrics/get_metrics_responses.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/workload/workload_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/workload/workload_models"
 )
 
 // GetMetricsReader is a Reader for the GetMetrics structure.

--- a/stackpath/api/workload/workload_client/virtual_machine_images/create_image_parameters.go
+++ b/stackpath/api/workload/workload_client/virtual_machine_images/create_image_parameters.go
@@ -15,7 +15,7 @@ import (
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/workload/workload_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/workload/workload_models"
 )
 
 // NewCreateImageParams creates a new CreateImageParams object,

--- a/stackpath/api/workload/workload_client/virtual_machine_images/create_image_responses.go
+++ b/stackpath/api/workload/workload_client/virtual_machine_images/create_image_responses.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/workload/workload_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/workload/workload_models"
 )
 
 // CreateImageReader is a Reader for the CreateImage structure.

--- a/stackpath/api/workload/workload_client/virtual_machine_images/delete_image_responses.go
+++ b/stackpath/api/workload/workload_client/virtual_machine_images/delete_image_responses.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/workload/workload_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/workload/workload_models"
 )
 
 // DeleteImageReader is a Reader for the DeleteImage structure.

--- a/stackpath/api/workload/workload_client/virtual_machine_images/delete_images_for_family_responses.go
+++ b/stackpath/api/workload/workload_client/virtual_machine_images/delete_images_for_family_responses.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/workload/workload_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/workload/workload_models"
 )
 
 // DeleteImagesForFamilyReader is a Reader for the DeleteImagesForFamily structure.

--- a/stackpath/api/workload/workload_client/virtual_machine_images/get_image_responses.go
+++ b/stackpath/api/workload/workload_client/virtual_machine_images/get_image_responses.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/workload/workload_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/workload/workload_models"
 )
 
 // GetImageReader is a Reader for the GetImage structure.

--- a/stackpath/api/workload/workload_client/virtual_machine_images/get_images_for_family_responses.go
+++ b/stackpath/api/workload/workload_client/virtual_machine_images/get_images_for_family_responses.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/workload/workload_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/workload/workload_models"
 )
 
 // GetImagesForFamilyReader is a Reader for the GetImagesForFamily structure.

--- a/stackpath/api/workload/workload_client/virtual_machine_images/get_images_responses.go
+++ b/stackpath/api/workload/workload_client/virtual_machine_images/get_images_responses.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/workload/workload_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/workload/workload_models"
 )
 
 // GetImagesReader is a Reader for the GetImages structure.

--- a/stackpath/api/workload/workload_client/virtual_machine_images/update_image_deprecation_parameters.go
+++ b/stackpath/api/workload/workload_client/virtual_machine_images/update_image_deprecation_parameters.go
@@ -15,7 +15,7 @@ import (
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/workload/workload_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/workload/workload_models"
 )
 
 // NewUpdateImageDeprecationParams creates a new UpdateImageDeprecationParams object,

--- a/stackpath/api/workload/workload_client/virtual_machine_images/update_image_deprecation_responses.go
+++ b/stackpath/api/workload/workload_client/virtual_machine_images/update_image_deprecation_responses.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/workload/workload_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/workload/workload_models"
 )
 
 // UpdateImageDeprecationReader is a Reader for the UpdateImageDeprecation structure.

--- a/stackpath/api/workload/workload_client/virtual_machine_images/update_image_parameters.go
+++ b/stackpath/api/workload/workload_client/virtual_machine_images/update_image_parameters.go
@@ -15,7 +15,7 @@ import (
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/workload/workload_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/workload/workload_models"
 )
 
 // NewUpdateImageParams creates a new UpdateImageParams object,

--- a/stackpath/api/workload/workload_client/virtual_machine_images/update_image_responses.go
+++ b/stackpath/api/workload/workload_client/virtual_machine_images/update_image_responses.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/workload/workload_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/workload/workload_models"
 )
 
 // UpdateImageReader is a Reader for the UpdateImage structure.

--- a/stackpath/api/workload/workload_client/workloads/create_workload_parameters.go
+++ b/stackpath/api/workload/workload_client/workloads/create_workload_parameters.go
@@ -15,7 +15,7 @@ import (
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/workload/workload_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/workload/workload_models"
 )
 
 // NewCreateWorkloadParams creates a new CreateWorkloadParams object,

--- a/stackpath/api/workload/workload_client/workloads/create_workload_responses.go
+++ b/stackpath/api/workload/workload_client/workloads/create_workload_responses.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/workload/workload_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/workload/workload_models"
 )
 
 // CreateWorkloadReader is a Reader for the CreateWorkload structure.

--- a/stackpath/api/workload/workload_client/workloads/delete_workload_responses.go
+++ b/stackpath/api/workload/workload_client/workloads/delete_workload_responses.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/workload/workload_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/workload/workload_models"
 )
 
 // DeleteWorkloadReader is a Reader for the DeleteWorkload structure.

--- a/stackpath/api/workload/workload_client/workloads/get_workload_responses.go
+++ b/stackpath/api/workload/workload_client/workloads/get_workload_responses.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/workload/workload_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/workload/workload_models"
 )
 
 // GetWorkloadReader is a Reader for the GetWorkload structure.

--- a/stackpath/api/workload/workload_client/workloads/get_workloads_responses.go
+++ b/stackpath/api/workload/workload_client/workloads/get_workloads_responses.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/workload/workload_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/workload/workload_models"
 )
 
 // GetWorkloadsReader is a Reader for the GetWorkloads structure.

--- a/stackpath/api/workload/workload_client/workloads/put_workload_parameters.go
+++ b/stackpath/api/workload/workload_client/workloads/put_workload_parameters.go
@@ -15,7 +15,7 @@ import (
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/workload/workload_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/workload/workload_models"
 )
 
 // NewPutWorkloadParams creates a new PutWorkloadParams object,

--- a/stackpath/api/workload/workload_client/workloads/put_workload_responses.go
+++ b/stackpath/api/workload/workload_client/workloads/put_workload_responses.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/workload/workload_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/workload/workload_models"
 )
 
 // PutWorkloadReader is a Reader for the PutWorkload structure.

--- a/stackpath/api/workload/workload_client/workloads/update_workload_parameters.go
+++ b/stackpath/api/workload/workload_client/workloads/update_workload_parameters.go
@@ -15,7 +15,7 @@ import (
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/workload/workload_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/workload/workload_models"
 )
 
 // NewUpdateWorkloadParams creates a new UpdateWorkloadParams object,

--- a/stackpath/api/workload/workload_client/workloads/update_workload_responses.go
+++ b/stackpath/api/workload/workload_client/workloads/update_workload_responses.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/workload/workload_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/workload/workload_models"
 )
 
 // UpdateWorkloadReader is a Reader for the UpdateWorkload structure.

--- a/stackpath/config.go
+++ b/stackpath/config.go
@@ -11,9 +11,9 @@ import (
 	"time"
 
 	"github.com/mitchellh/go-homedir"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_client"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/storage/storage_client"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/workload/workload_client"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_client"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/storage/storage_client"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/workload/workload_client"
 
 	httptransport "github.com/go-openapi/runtime/client"
 

--- a/stackpath/errors.go
+++ b/stackpath/errors.go
@@ -7,9 +7,9 @@ import (
 	"net/url"
 	"reflect"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_models"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/storage/storage_models"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/workload/workload_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/storage/storage_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/workload/workload_models"
 	"golang.org/x/oauth2"
 )
 

--- a/stackpath/errors_test.go
+++ b/stackpath/errors_test.go
@@ -6,8 +6,8 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_client/network_policies"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_client/network_policies"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_models"
 	"golang.org/x/oauth2"
 )
 

--- a/stackpath/resource_stackpath_compute_network_policy.go
+++ b/stackpath/resource_stackpath_compute_network_policy.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_client/network_policies"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_client/network_policies"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_models"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/stackpath/resource_stackpath_compute_network_policy_test.go
+++ b/stackpath/resource_stackpath_compute_network_policy_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_client/network_policies"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_client/network_policies"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_models"
 )
 
 func TestAccComputeNetworkPolicy(t *testing.T) {

--- a/stackpath/resource_stackpath_compute_vpc_network.go
+++ b/stackpath/resource_stackpath_compute_vpc_network.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_client/virtual_private_cloud"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_client/virtual_private_cloud"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_models"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/stackpath/resource_stackpath_compute_vpc_network_subnet.go
+++ b/stackpath/resource_stackpath_compute_vpc_network_subnet.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_client/virtual_private_cloud"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_client/virtual_private_cloud"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_models"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/stackpath/resource_stackpath_compute_vpc_network_subnet_test.go
+++ b/stackpath/resource_stackpath_compute_vpc_network_subnet_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_client/virtual_private_cloud"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_client/virtual_private_cloud"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_models"
 )
 
 func TestAccComputeVPCNetworkSubnetIPv4(t *testing.T) {

--- a/stackpath/resource_stackpath_compute_vpc_network_test.go
+++ b/stackpath/resource_stackpath_compute_vpc_network_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_client/virtual_private_cloud"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_client/virtual_private_cloud"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_models"
 )
 
 func TestAccComputeVPCNetwork(t *testing.T) {

--- a/stackpath/resource_stackpath_compute_vpc_route.go
+++ b/stackpath/resource_stackpath_compute_vpc_route.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_client/virtual_private_cloud"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_client/virtual_private_cloud"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_models"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/stackpath/resource_stackpath_compute_vpc_route_test.go
+++ b/stackpath/resource_stackpath_compute_vpc_route_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_client/virtual_private_cloud"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_client/virtual_private_cloud"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_models"
 )
 
 func TestAccComputeVPCRoute(t *testing.T) {

--- a/stackpath/resource_stackpath_compute_workload.go
+++ b/stackpath/resource_stackpath_compute_workload.go
@@ -6,9 +6,9 @@ import (
 	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/workload/workload_client/instances"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/workload/workload_client/workloads"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/workload/workload_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/workload/workload_client/instances"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/workload/workload_client/workloads"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/workload/workload_models"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/stackpath/resource_stackpath_compute_workload_test.go
+++ b/stackpath/resource_stackpath_compute_workload_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/workload/workload_client/workloads"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/workload/workload_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/workload/workload_client/workloads"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/workload/workload_models"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"

--- a/stackpath/resource_stackpath_object_storage_bucket.go
+++ b/stackpath/resource_stackpath_object_storage_bucket.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/storage/storage_client/buckets"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/storage/storage_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/storage/storage_client/buckets"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/storage/storage_models"
 )
 
 func resourceObjectStorageBucket() *schema.Resource {

--- a/stackpath/resource_stackpath_object_storage_bucket_test.go
+++ b/stackpath/resource_stackpath_object_storage_bucket_test.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/storage/storage_client/buckets"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/storage/storage_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/storage/storage_client/buckets"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/storage/storage_models"
 )
 
 // Create bucket and update visibility

--- a/stackpath/structure_compute_network.go
+++ b/stackpath/structure_compute_network.go
@@ -2,7 +2,7 @@ package stackpath
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_models"
 )
 
 func convertComputeNetwork(data *schema.ResourceData) *ipam_models.NetworkNetwork {

--- a/stackpath/structure_compute_network_policy.go
+++ b/stackpath/structure_compute_network_policy.go
@@ -2,7 +2,7 @@ package stackpath
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_models"
 )
 
 func convertComputeNetworkPolicy(data *schema.ResourceData) *ipam_models.V1NetworkPolicy {

--- a/stackpath/structure_compute_network_subnet.go
+++ b/stackpath/structure_compute_network_subnet.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_models"
 )
 
 func formatNetworkSubnetID(networkID, subnetID string) string {

--- a/stackpath/structure_compute_route.go
+++ b/stackpath/structure_compute_route.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_models"
 )
 
 func formatRouteID(networkID, routeID string) string {

--- a/stackpath/structure_compute_workload.go
+++ b/stackpath/structure_compute_workload.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/workload/workload_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/workload/workload_models"
 
 	"log"
 	"strings"

--- a/stackpath/structure_compute_workload_instance.go
+++ b/stackpath/structure_compute_workload_instance.go
@@ -1,7 +1,7 @@
 package stackpath
 
 import (
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/workload/workload_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/workload/workload_models"
 )
 
 func flattenComputeWorkloadInstance(instance *workload_models.Workloadv1Instance) map[string]interface{} {

--- a/stackpath/structure_core.go
+++ b/stackpath/structure_core.go
@@ -2,8 +2,8 @@ package stackpath
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/ipam/ipam_models"
-	"github.com/stackpath/terraform-provider-stackpath/stackpath/api/workload/workload_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/ipam/ipam_models"
+	"github.com/stackpath/terraform-provider-stackpath/v2/stackpath/api/workload/workload_models"
 )
 
 func convertComputeMatchExpression(data []interface{}) []*workload_models.V1MatchExpression {

--- a/stackpath/user_agent_transport.go
+++ b/stackpath/user_agent_transport.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/stackpath/terraform-provider-stackpath/version"
+	"github.com/stackpath/terraform-provider-stackpath/v2/version"
 )
 
 const userAgentFormat = "HashiCorp Terraform/%s (+https://www.terraform.io) terraform-provider-stackpath/%s (+https://registry.terraform.io/providers/stackpath/stackpath)"
 
 // UserAgentTransport is an http RoundTripper that sets a descriptive User-Agent
-//header for all StackPath API requests.
+// header for all StackPath API requests.
 type UserAgentTransport struct {
 	terraformVersion string
 	http.RoundTripper


### PR DESCRIPTION
## Description

Previously, the project was upgraded to v2 without setting the module path to v2:

If we try to import the v2 library we get the following error:
```
go: github.com/stackpath/terraform-provider-stackpath/v2@v2.0.0: invalid version: go.mod has non-.../v2 module path "github.com/stackpath/terraform-provider-stackpath" (and .../v2/go.mod does not exist) at revision v2.0.0
```

To fix this, we need to update the module path to:

```
module github.com/stackpath/terraform-provider-stackpath/v2
```

As well as to fix all repository-wide import paths.

**This is a default behaviour enforced by Go's module system**