### PR TITLE
client code and models generation with go-swagger v0.27.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -87,6 +87,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.21
-
-toolchain go1.21.3
+go 1.19

--- a/go.mod
+++ b/go.mod
@@ -87,4 +87,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.19
+go 1.21
+
+toolchain go1.21.3

--- a/stackpath/api/ipam/ipam_client/network_policies/create_network_policy_responses.go
+++ b/stackpath/api/ipam/ipam_client/network_policies/create_network_policy_responses.go
@@ -59,7 +59,7 @@ func NewCreateNetworkPolicyOK() *CreateNetworkPolicyOK {
 }
 
 /*
-	CreateNetworkPolicyOK describes a response with status code 200, with default header values.
+CreateNetworkPolicyOK describes a response with status code 200, with default header values.
 
 CreateNetworkPolicyOK create network policy o k
 */
@@ -92,7 +92,7 @@ func NewCreateNetworkPolicyUnauthorized() *CreateNetworkPolicyUnauthorized {
 }
 
 /*
-	CreateNetworkPolicyUnauthorized describes a response with status code 401, with default header values.
+CreateNetworkPolicyUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -125,7 +125,7 @@ func NewCreateNetworkPolicyInternalServerError() *CreateNetworkPolicyInternalSer
 }
 
 /*
-	CreateNetworkPolicyInternalServerError describes a response with status code 500, with default header values.
+CreateNetworkPolicyInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -160,7 +160,7 @@ func NewCreateNetworkPolicyDefault(code int) *CreateNetworkPolicyDefault {
 }
 
 /*
-	CreateNetworkPolicyDefault describes a response with status code -1, with default header values.
+CreateNetworkPolicyDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/ipam/ipam_client/network_policies/delete_network_policy_parameters.go
+++ b/stackpath/api/ipam/ipam_client/network_policies/delete_network_policy_parameters.go
@@ -52,10 +52,12 @@ func NewDeleteNetworkPolicyParamsWithHTTPClient(client *http.Client) *DeleteNetw
 	}
 }
 
-/* DeleteNetworkPolicyParams contains all the parameters to send to the API endpoint
-   for the delete network policy operation.
+/*
+DeleteNetworkPolicyParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the delete network policy operation.
+
+	Typically these are written to a http.Request.
 */
 type DeleteNetworkPolicyParams struct {
 

--- a/stackpath/api/ipam/ipam_client/network_policies/delete_network_policy_responses.go
+++ b/stackpath/api/ipam/ipam_client/network_policies/delete_network_policy_responses.go
@@ -59,7 +59,7 @@ func NewDeleteNetworkPolicyNoContent() *DeleteNetworkPolicyNoContent {
 }
 
 /*
-	DeleteNetworkPolicyNoContent describes a response with status code 204, with default header values.
+DeleteNetworkPolicyNoContent describes a response with status code 204, with default header values.
 
 No content
 */
@@ -81,7 +81,7 @@ func NewDeleteNetworkPolicyUnauthorized() *DeleteNetworkPolicyUnauthorized {
 }
 
 /*
-	DeleteNetworkPolicyUnauthorized describes a response with status code 401, with default header values.
+DeleteNetworkPolicyUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -114,7 +114,7 @@ func NewDeleteNetworkPolicyInternalServerError() *DeleteNetworkPolicyInternalSer
 }
 
 /*
-	DeleteNetworkPolicyInternalServerError describes a response with status code 500, with default header values.
+DeleteNetworkPolicyInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -149,7 +149,7 @@ func NewDeleteNetworkPolicyDefault(code int) *DeleteNetworkPolicyDefault {
 }
 
 /*
-	DeleteNetworkPolicyDefault describes a response with status code -1, with default header values.
+DeleteNetworkPolicyDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/ipam/ipam_client/network_policies/get_network_policies_parameters.go
+++ b/stackpath/api/ipam/ipam_client/network_policies/get_network_policies_parameters.go
@@ -52,10 +52,12 @@ func NewGetNetworkPoliciesParamsWithHTTPClient(client *http.Client) *GetNetworkP
 	}
 }
 
-/* GetNetworkPoliciesParams contains all the parameters to send to the API endpoint
-   for the get network policies operation.
+/*
+GetNetworkPoliciesParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get network policies operation.
+
+	Typically these are written to a http.Request.
 */
 type GetNetworkPoliciesParams struct {
 

--- a/stackpath/api/ipam/ipam_client/network_policies/get_network_policies_responses.go
+++ b/stackpath/api/ipam/ipam_client/network_policies/get_network_policies_responses.go
@@ -59,7 +59,7 @@ func NewGetNetworkPoliciesOK() *GetNetworkPoliciesOK {
 }
 
 /*
-	GetNetworkPoliciesOK describes a response with status code 200, with default header values.
+GetNetworkPoliciesOK describes a response with status code 200, with default header values.
 
 GetNetworkPoliciesOK get network policies o k
 */
@@ -92,7 +92,7 @@ func NewGetNetworkPoliciesUnauthorized() *GetNetworkPoliciesUnauthorized {
 }
 
 /*
-	GetNetworkPoliciesUnauthorized describes a response with status code 401, with default header values.
+GetNetworkPoliciesUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -125,7 +125,7 @@ func NewGetNetworkPoliciesInternalServerError() *GetNetworkPoliciesInternalServe
 }
 
 /*
-	GetNetworkPoliciesInternalServerError describes a response with status code 500, with default header values.
+GetNetworkPoliciesInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -160,7 +160,7 @@ func NewGetNetworkPoliciesDefault(code int) *GetNetworkPoliciesDefault {
 }
 
 /*
-	GetNetworkPoliciesDefault describes a response with status code -1, with default header values.
+GetNetworkPoliciesDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/ipam/ipam_client/network_policies/get_network_policy_parameters.go
+++ b/stackpath/api/ipam/ipam_client/network_policies/get_network_policy_parameters.go
@@ -52,10 +52,12 @@ func NewGetNetworkPolicyParamsWithHTTPClient(client *http.Client) *GetNetworkPol
 	}
 }
 
-/* GetNetworkPolicyParams contains all the parameters to send to the API endpoint
-   for the get network policy operation.
+/*
+GetNetworkPolicyParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get network policy operation.
+
+	Typically these are written to a http.Request.
 */
 type GetNetworkPolicyParams struct {
 

--- a/stackpath/api/ipam/ipam_client/network_policies/get_network_policy_responses.go
+++ b/stackpath/api/ipam/ipam_client/network_policies/get_network_policy_responses.go
@@ -59,7 +59,7 @@ func NewGetNetworkPolicyOK() *GetNetworkPolicyOK {
 }
 
 /*
-	GetNetworkPolicyOK describes a response with status code 200, with default header values.
+GetNetworkPolicyOK describes a response with status code 200, with default header values.
 
 GetNetworkPolicyOK get network policy o k
 */
@@ -92,7 +92,7 @@ func NewGetNetworkPolicyUnauthorized() *GetNetworkPolicyUnauthorized {
 }
 
 /*
-	GetNetworkPolicyUnauthorized describes a response with status code 401, with default header values.
+GetNetworkPolicyUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -125,7 +125,7 @@ func NewGetNetworkPolicyInternalServerError() *GetNetworkPolicyInternalServerErr
 }
 
 /*
-	GetNetworkPolicyInternalServerError describes a response with status code 500, with default header values.
+GetNetworkPolicyInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -160,7 +160,7 @@ func NewGetNetworkPolicyDefault(code int) *GetNetworkPolicyDefault {
 }
 
 /*
-	GetNetworkPolicyDefault describes a response with status code -1, with default header values.
+GetNetworkPolicyDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/ipam/ipam_client/network_policies/network_policies_client.go
+++ b/stackpath/api/ipam/ipam_client/network_policies/network_policies_client.go
@@ -42,7 +42,7 @@ type ClientService interface {
 }
 
 /*
-  CreateNetworkPolicy creates a policy
+CreateNetworkPolicy creates a policy
 */
 func (a *Client) CreateNetworkPolicy(params *CreateNetworkPolicyParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateNetworkPolicyOK, error) {
 	// TODO: Validate the params before sending
@@ -80,7 +80,7 @@ func (a *Client) CreateNetworkPolicy(params *CreateNetworkPolicyParams, authInfo
 }
 
 /*
-  DeleteNetworkPolicy deletes a policy
+DeleteNetworkPolicy deletes a policy
 */
 func (a *Client) DeleteNetworkPolicy(params *DeleteNetworkPolicyParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteNetworkPolicyNoContent, error) {
 	// TODO: Validate the params before sending
@@ -118,7 +118,7 @@ func (a *Client) DeleteNetworkPolicy(params *DeleteNetworkPolicyParams, authInfo
 }
 
 /*
-  GetNetworkPolicies gets all policies
+GetNetworkPolicies gets all policies
 */
 func (a *Client) GetNetworkPolicies(params *GetNetworkPoliciesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetNetworkPoliciesOK, error) {
 	// TODO: Validate the params before sending
@@ -156,7 +156,7 @@ func (a *Client) GetNetworkPolicies(params *GetNetworkPoliciesParams, authInfo r
 }
 
 /*
-  GetNetworkPolicy gets a policy
+GetNetworkPolicy gets a policy
 */
 func (a *Client) GetNetworkPolicy(params *GetNetworkPolicyParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetNetworkPolicyOK, error) {
 	// TODO: Validate the params before sending
@@ -194,7 +194,7 @@ func (a *Client) GetNetworkPolicy(params *GetNetworkPolicyParams, authInfo runti
 }
 
 /*
-  UpdateNetworkPolicy updates a policy
+UpdateNetworkPolicy updates a policy
 */
 func (a *Client) UpdateNetworkPolicy(params *UpdateNetworkPolicyParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UpdateNetworkPolicyOK, error) {
 	// TODO: Validate the params before sending

--- a/stackpath/api/ipam/ipam_client/network_policies/update_network_policy_responses.go
+++ b/stackpath/api/ipam/ipam_client/network_policies/update_network_policy_responses.go
@@ -59,7 +59,7 @@ func NewUpdateNetworkPolicyOK() *UpdateNetworkPolicyOK {
 }
 
 /*
-	UpdateNetworkPolicyOK describes a response with status code 200, with default header values.
+UpdateNetworkPolicyOK describes a response with status code 200, with default header values.
 
 UpdateNetworkPolicyOK update network policy o k
 */
@@ -92,7 +92,7 @@ func NewUpdateNetworkPolicyUnauthorized() *UpdateNetworkPolicyUnauthorized {
 }
 
 /*
-	UpdateNetworkPolicyUnauthorized describes a response with status code 401, with default header values.
+UpdateNetworkPolicyUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -125,7 +125,7 @@ func NewUpdateNetworkPolicyInternalServerError() *UpdateNetworkPolicyInternalSer
 }
 
 /*
-	UpdateNetworkPolicyInternalServerError describes a response with status code 500, with default header values.
+UpdateNetworkPolicyInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -160,7 +160,7 @@ func NewUpdateNetworkPolicyDefault(code int) *UpdateNetworkPolicyDefault {
 }
 
 /*
-	UpdateNetworkPolicyDefault describes a response with status code -1, with default header values.
+UpdateNetworkPolicyDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/ipam/ipam_client/virtual_private_cloud/create_network_responses.go
+++ b/stackpath/api/ipam/ipam_client/virtual_private_cloud/create_network_responses.go
@@ -59,7 +59,7 @@ func NewCreateNetworkOK() *CreateNetworkOK {
 }
 
 /*
-	CreateNetworkOK describes a response with status code 200, with default header values.
+CreateNetworkOK describes a response with status code 200, with default header values.
 
 CreateNetworkOK create network o k
 */
@@ -92,7 +92,7 @@ func NewCreateNetworkUnauthorized() *CreateNetworkUnauthorized {
 }
 
 /*
-	CreateNetworkUnauthorized describes a response with status code 401, with default header values.
+CreateNetworkUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -125,7 +125,7 @@ func NewCreateNetworkInternalServerError() *CreateNetworkInternalServerError {
 }
 
 /*
-	CreateNetworkInternalServerError describes a response with status code 500, with default header values.
+CreateNetworkInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -160,7 +160,7 @@ func NewCreateNetworkDefault(code int) *CreateNetworkDefault {
 }
 
 /*
-	CreateNetworkDefault describes a response with status code -1, with default header values.
+CreateNetworkDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/ipam/ipam_client/virtual_private_cloud/create_network_subnet_responses.go
+++ b/stackpath/api/ipam/ipam_client/virtual_private_cloud/create_network_subnet_responses.go
@@ -59,7 +59,7 @@ func NewCreateNetworkSubnetOK() *CreateNetworkSubnetOK {
 }
 
 /*
-	CreateNetworkSubnetOK describes a response with status code 200, with default header values.
+CreateNetworkSubnetOK describes a response with status code 200, with default header values.
 
 CreateNetworkSubnetOK create network subnet o k
 */
@@ -92,7 +92,7 @@ func NewCreateNetworkSubnetUnauthorized() *CreateNetworkSubnetUnauthorized {
 }
 
 /*
-	CreateNetworkSubnetUnauthorized describes a response with status code 401, with default header values.
+CreateNetworkSubnetUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -125,7 +125,7 @@ func NewCreateNetworkSubnetInternalServerError() *CreateNetworkSubnetInternalSer
 }
 
 /*
-	CreateNetworkSubnetInternalServerError describes a response with status code 500, with default header values.
+CreateNetworkSubnetInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -160,7 +160,7 @@ func NewCreateNetworkSubnetDefault(code int) *CreateNetworkSubnetDefault {
 }
 
 /*
-	CreateNetworkSubnetDefault describes a response with status code -1, with default header values.
+CreateNetworkSubnetDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/ipam/ipam_client/virtual_private_cloud/create_route_responses.go
+++ b/stackpath/api/ipam/ipam_client/virtual_private_cloud/create_route_responses.go
@@ -59,7 +59,7 @@ func NewCreateRouteOK() *CreateRouteOK {
 }
 
 /*
-	CreateRouteOK describes a response with status code 200, with default header values.
+CreateRouteOK describes a response with status code 200, with default header values.
 
 CreateRouteOK create route o k
 */
@@ -92,7 +92,7 @@ func NewCreateRouteUnauthorized() *CreateRouteUnauthorized {
 }
 
 /*
-	CreateRouteUnauthorized describes a response with status code 401, with default header values.
+CreateRouteUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -125,7 +125,7 @@ func NewCreateRouteInternalServerError() *CreateRouteInternalServerError {
 }
 
 /*
-	CreateRouteInternalServerError describes a response with status code 500, with default header values.
+CreateRouteInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -160,7 +160,7 @@ func NewCreateRouteDefault(code int) *CreateRouteDefault {
 }
 
 /*
-	CreateRouteDefault describes a response with status code -1, with default header values.
+CreateRouteDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/ipam/ipam_client/virtual_private_cloud/delete_network_parameters.go
+++ b/stackpath/api/ipam/ipam_client/virtual_private_cloud/delete_network_parameters.go
@@ -52,10 +52,12 @@ func NewDeleteNetworkParamsWithHTTPClient(client *http.Client) *DeleteNetworkPar
 	}
 }
 
-/* DeleteNetworkParams contains all the parameters to send to the API endpoint
-   for the delete network operation.
+/*
+DeleteNetworkParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the delete network operation.
+
+	Typically these are written to a http.Request.
 */
 type DeleteNetworkParams struct {
 

--- a/stackpath/api/ipam/ipam_client/virtual_private_cloud/delete_network_responses.go
+++ b/stackpath/api/ipam/ipam_client/virtual_private_cloud/delete_network_responses.go
@@ -59,7 +59,7 @@ func NewDeleteNetworkNoContent() *DeleteNetworkNoContent {
 }
 
 /*
-	DeleteNetworkNoContent describes a response with status code 204, with default header values.
+DeleteNetworkNoContent describes a response with status code 204, with default header values.
 
 No content
 */
@@ -81,7 +81,7 @@ func NewDeleteNetworkUnauthorized() *DeleteNetworkUnauthorized {
 }
 
 /*
-	DeleteNetworkUnauthorized describes a response with status code 401, with default header values.
+DeleteNetworkUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -114,7 +114,7 @@ func NewDeleteNetworkInternalServerError() *DeleteNetworkInternalServerError {
 }
 
 /*
-	DeleteNetworkInternalServerError describes a response with status code 500, with default header values.
+DeleteNetworkInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -149,7 +149,7 @@ func NewDeleteNetworkDefault(code int) *DeleteNetworkDefault {
 }
 
 /*
-	DeleteNetworkDefault describes a response with status code -1, with default header values.
+DeleteNetworkDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/ipam/ipam_client/virtual_private_cloud/delete_network_subnet_parameters.go
+++ b/stackpath/api/ipam/ipam_client/virtual_private_cloud/delete_network_subnet_parameters.go
@@ -52,10 +52,12 @@ func NewDeleteNetworkSubnetParamsWithHTTPClient(client *http.Client) *DeleteNetw
 	}
 }
 
-/* DeleteNetworkSubnetParams contains all the parameters to send to the API endpoint
-   for the delete network subnet operation.
+/*
+DeleteNetworkSubnetParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the delete network subnet operation.
+
+	Typically these are written to a http.Request.
 */
 type DeleteNetworkSubnetParams struct {
 

--- a/stackpath/api/ipam/ipam_client/virtual_private_cloud/delete_network_subnet_responses.go
+++ b/stackpath/api/ipam/ipam_client/virtual_private_cloud/delete_network_subnet_responses.go
@@ -59,7 +59,7 @@ func NewDeleteNetworkSubnetNoContent() *DeleteNetworkSubnetNoContent {
 }
 
 /*
-	DeleteNetworkSubnetNoContent describes a response with status code 204, with default header values.
+DeleteNetworkSubnetNoContent describes a response with status code 204, with default header values.
 
 No content
 */
@@ -81,7 +81,7 @@ func NewDeleteNetworkSubnetUnauthorized() *DeleteNetworkSubnetUnauthorized {
 }
 
 /*
-	DeleteNetworkSubnetUnauthorized describes a response with status code 401, with default header values.
+DeleteNetworkSubnetUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -114,7 +114,7 @@ func NewDeleteNetworkSubnetInternalServerError() *DeleteNetworkSubnetInternalSer
 }
 
 /*
-	DeleteNetworkSubnetInternalServerError describes a response with status code 500, with default header values.
+DeleteNetworkSubnetInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -149,7 +149,7 @@ func NewDeleteNetworkSubnetDefault(code int) *DeleteNetworkSubnetDefault {
 }
 
 /*
-	DeleteNetworkSubnetDefault describes a response with status code -1, with default header values.
+DeleteNetworkSubnetDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/ipam/ipam_client/virtual_private_cloud/delete_route_parameters.go
+++ b/stackpath/api/ipam/ipam_client/virtual_private_cloud/delete_route_parameters.go
@@ -52,10 +52,12 @@ func NewDeleteRouteParamsWithHTTPClient(client *http.Client) *DeleteRouteParams 
 	}
 }
 
-/* DeleteRouteParams contains all the parameters to send to the API endpoint
-   for the delete route operation.
+/*
+DeleteRouteParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the delete route operation.
+
+	Typically these are written to a http.Request.
 */
 type DeleteRouteParams struct {
 

--- a/stackpath/api/ipam/ipam_client/virtual_private_cloud/delete_route_responses.go
+++ b/stackpath/api/ipam/ipam_client/virtual_private_cloud/delete_route_responses.go
@@ -59,7 +59,7 @@ func NewDeleteRouteNoContent() *DeleteRouteNoContent {
 }
 
 /*
-	DeleteRouteNoContent describes a response with status code 204, with default header values.
+DeleteRouteNoContent describes a response with status code 204, with default header values.
 
 No content
 */
@@ -81,7 +81,7 @@ func NewDeleteRouteUnauthorized() *DeleteRouteUnauthorized {
 }
 
 /*
-	DeleteRouteUnauthorized describes a response with status code 401, with default header values.
+DeleteRouteUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -114,7 +114,7 @@ func NewDeleteRouteInternalServerError() *DeleteRouteInternalServerError {
 }
 
 /*
-	DeleteRouteInternalServerError describes a response with status code 500, with default header values.
+DeleteRouteInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -149,7 +149,7 @@ func NewDeleteRouteDefault(code int) *DeleteRouteDefault {
 }
 
 /*
-	DeleteRouteDefault describes a response with status code -1, with default header values.
+DeleteRouteDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/ipam/ipam_client/virtual_private_cloud/get_network_parameters.go
+++ b/stackpath/api/ipam/ipam_client/virtual_private_cloud/get_network_parameters.go
@@ -52,10 +52,12 @@ func NewGetNetworkParamsWithHTTPClient(client *http.Client) *GetNetworkParams {
 	}
 }
 
-/* GetNetworkParams contains all the parameters to send to the API endpoint
-   for the get network operation.
+/*
+GetNetworkParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get network operation.
+
+	Typically these are written to a http.Request.
 */
 type GetNetworkParams struct {
 

--- a/stackpath/api/ipam/ipam_client/virtual_private_cloud/get_network_responses.go
+++ b/stackpath/api/ipam/ipam_client/virtual_private_cloud/get_network_responses.go
@@ -59,7 +59,7 @@ func NewGetNetworkOK() *GetNetworkOK {
 }
 
 /*
-	GetNetworkOK describes a response with status code 200, with default header values.
+GetNetworkOK describes a response with status code 200, with default header values.
 
 GetNetworkOK get network o k
 */
@@ -92,7 +92,7 @@ func NewGetNetworkUnauthorized() *GetNetworkUnauthorized {
 }
 
 /*
-	GetNetworkUnauthorized describes a response with status code 401, with default header values.
+GetNetworkUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -125,7 +125,7 @@ func NewGetNetworkInternalServerError() *GetNetworkInternalServerError {
 }
 
 /*
-	GetNetworkInternalServerError describes a response with status code 500, with default header values.
+GetNetworkInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -160,7 +160,7 @@ func NewGetNetworkDefault(code int) *GetNetworkDefault {
 }
 
 /*
-	GetNetworkDefault describes a response with status code -1, with default header values.
+GetNetworkDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/ipam/ipam_client/virtual_private_cloud/get_network_subnet_parameters.go
+++ b/stackpath/api/ipam/ipam_client/virtual_private_cloud/get_network_subnet_parameters.go
@@ -52,10 +52,12 @@ func NewGetNetworkSubnetParamsWithHTTPClient(client *http.Client) *GetNetworkSub
 	}
 }
 
-/* GetNetworkSubnetParams contains all the parameters to send to the API endpoint
-   for the get network subnet operation.
+/*
+GetNetworkSubnetParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get network subnet operation.
+
+	Typically these are written to a http.Request.
 */
 type GetNetworkSubnetParams struct {
 

--- a/stackpath/api/ipam/ipam_client/virtual_private_cloud/get_network_subnet_responses.go
+++ b/stackpath/api/ipam/ipam_client/virtual_private_cloud/get_network_subnet_responses.go
@@ -59,7 +59,7 @@ func NewGetNetworkSubnetOK() *GetNetworkSubnetOK {
 }
 
 /*
-	GetNetworkSubnetOK describes a response with status code 200, with default header values.
+GetNetworkSubnetOK describes a response with status code 200, with default header values.
 
 GetNetworkSubnetOK get network subnet o k
 */
@@ -92,7 +92,7 @@ func NewGetNetworkSubnetUnauthorized() *GetNetworkSubnetUnauthorized {
 }
 
 /*
-	GetNetworkSubnetUnauthorized describes a response with status code 401, with default header values.
+GetNetworkSubnetUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -125,7 +125,7 @@ func NewGetNetworkSubnetInternalServerError() *GetNetworkSubnetInternalServerErr
 }
 
 /*
-	GetNetworkSubnetInternalServerError describes a response with status code 500, with default header values.
+GetNetworkSubnetInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -160,7 +160,7 @@ func NewGetNetworkSubnetDefault(code int) *GetNetworkSubnetDefault {
 }
 
 /*
-	GetNetworkSubnetDefault describes a response with status code -1, with default header values.
+GetNetworkSubnetDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/ipam/ipam_client/virtual_private_cloud/get_network_subnets_parameters.go
+++ b/stackpath/api/ipam/ipam_client/virtual_private_cloud/get_network_subnets_parameters.go
@@ -52,10 +52,12 @@ func NewGetNetworkSubnetsParamsWithHTTPClient(client *http.Client) *GetNetworkSu
 	}
 }
 
-/* GetNetworkSubnetsParams contains all the parameters to send to the API endpoint
-   for the get network subnets operation.
+/*
+GetNetworkSubnetsParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get network subnets operation.
+
+	Typically these are written to a http.Request.
 */
 type GetNetworkSubnetsParams struct {
 

--- a/stackpath/api/ipam/ipam_client/virtual_private_cloud/get_network_subnets_responses.go
+++ b/stackpath/api/ipam/ipam_client/virtual_private_cloud/get_network_subnets_responses.go
@@ -59,7 +59,7 @@ func NewGetNetworkSubnetsOK() *GetNetworkSubnetsOK {
 }
 
 /*
-	GetNetworkSubnetsOK describes a response with status code 200, with default header values.
+GetNetworkSubnetsOK describes a response with status code 200, with default header values.
 
 GetNetworkSubnetsOK get network subnets o k
 */
@@ -92,7 +92,7 @@ func NewGetNetworkSubnetsUnauthorized() *GetNetworkSubnetsUnauthorized {
 }
 
 /*
-	GetNetworkSubnetsUnauthorized describes a response with status code 401, with default header values.
+GetNetworkSubnetsUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -125,7 +125,7 @@ func NewGetNetworkSubnetsInternalServerError() *GetNetworkSubnetsInternalServerE
 }
 
 /*
-	GetNetworkSubnetsInternalServerError describes a response with status code 500, with default header values.
+GetNetworkSubnetsInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -160,7 +160,7 @@ func NewGetNetworkSubnetsDefault(code int) *GetNetworkSubnetsDefault {
 }
 
 /*
-	GetNetworkSubnetsDefault describes a response with status code -1, with default header values.
+GetNetworkSubnetsDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/ipam/ipam_client/virtual_private_cloud/get_networks_parameters.go
+++ b/stackpath/api/ipam/ipam_client/virtual_private_cloud/get_networks_parameters.go
@@ -52,10 +52,12 @@ func NewGetNetworksParamsWithHTTPClient(client *http.Client) *GetNetworksParams 
 	}
 }
 
-/* GetNetworksParams contains all the parameters to send to the API endpoint
-   for the get networks operation.
+/*
+GetNetworksParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get networks operation.
+
+	Typically these are written to a http.Request.
 */
 type GetNetworksParams struct {
 

--- a/stackpath/api/ipam/ipam_client/virtual_private_cloud/get_networks_responses.go
+++ b/stackpath/api/ipam/ipam_client/virtual_private_cloud/get_networks_responses.go
@@ -59,7 +59,7 @@ func NewGetNetworksOK() *GetNetworksOK {
 }
 
 /*
-	GetNetworksOK describes a response with status code 200, with default header values.
+GetNetworksOK describes a response with status code 200, with default header values.
 
 GetNetworksOK get networks o k
 */
@@ -92,7 +92,7 @@ func NewGetNetworksUnauthorized() *GetNetworksUnauthorized {
 }
 
 /*
-	GetNetworksUnauthorized describes a response with status code 401, with default header values.
+GetNetworksUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -125,7 +125,7 @@ func NewGetNetworksInternalServerError() *GetNetworksInternalServerError {
 }
 
 /*
-	GetNetworksInternalServerError describes a response with status code 500, with default header values.
+GetNetworksInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -160,7 +160,7 @@ func NewGetNetworksDefault(code int) *GetNetworksDefault {
 }
 
 /*
-	GetNetworksDefault describes a response with status code -1, with default header values.
+GetNetworksDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/ipam/ipam_client/virtual_private_cloud/get_route_parameters.go
+++ b/stackpath/api/ipam/ipam_client/virtual_private_cloud/get_route_parameters.go
@@ -52,10 +52,12 @@ func NewGetRouteParamsWithHTTPClient(client *http.Client) *GetRouteParams {
 	}
 }
 
-/* GetRouteParams contains all the parameters to send to the API endpoint
-   for the get route operation.
+/*
+GetRouteParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get route operation.
+
+	Typically these are written to a http.Request.
 */
 type GetRouteParams struct {
 

--- a/stackpath/api/ipam/ipam_client/virtual_private_cloud/get_route_responses.go
+++ b/stackpath/api/ipam/ipam_client/virtual_private_cloud/get_route_responses.go
@@ -59,7 +59,7 @@ func NewGetRouteOK() *GetRouteOK {
 }
 
 /*
-	GetRouteOK describes a response with status code 200, with default header values.
+GetRouteOK describes a response with status code 200, with default header values.
 
 GetRouteOK get route o k
 */
@@ -92,7 +92,7 @@ func NewGetRouteUnauthorized() *GetRouteUnauthorized {
 }
 
 /*
-	GetRouteUnauthorized describes a response with status code 401, with default header values.
+GetRouteUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -125,7 +125,7 @@ func NewGetRouteInternalServerError() *GetRouteInternalServerError {
 }
 
 /*
-	GetRouteInternalServerError describes a response with status code 500, with default header values.
+GetRouteInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -160,7 +160,7 @@ func NewGetRouteDefault(code int) *GetRouteDefault {
 }
 
 /*
-	GetRouteDefault describes a response with status code -1, with default header values.
+GetRouteDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/ipam/ipam_client/virtual_private_cloud/get_routes_parameters.go
+++ b/stackpath/api/ipam/ipam_client/virtual_private_cloud/get_routes_parameters.go
@@ -52,10 +52,12 @@ func NewGetRoutesParamsWithHTTPClient(client *http.Client) *GetRoutesParams {
 	}
 }
 
-/* GetRoutesParams contains all the parameters to send to the API endpoint
-   for the get routes operation.
+/*
+GetRoutesParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get routes operation.
+
+	Typically these are written to a http.Request.
 */
 type GetRoutesParams struct {
 

--- a/stackpath/api/ipam/ipam_client/virtual_private_cloud/get_routes_responses.go
+++ b/stackpath/api/ipam/ipam_client/virtual_private_cloud/get_routes_responses.go
@@ -59,7 +59,7 @@ func NewGetRoutesOK() *GetRoutesOK {
 }
 
 /*
-	GetRoutesOK describes a response with status code 200, with default header values.
+GetRoutesOK describes a response with status code 200, with default header values.
 
 GetRoutesOK get routes o k
 */
@@ -92,7 +92,7 @@ func NewGetRoutesUnauthorized() *GetRoutesUnauthorized {
 }
 
 /*
-	GetRoutesUnauthorized describes a response with status code 401, with default header values.
+GetRoutesUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -125,7 +125,7 @@ func NewGetRoutesInternalServerError() *GetRoutesInternalServerError {
 }
 
 /*
-	GetRoutesInternalServerError describes a response with status code 500, with default header values.
+GetRoutesInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -160,7 +160,7 @@ func NewGetRoutesDefault(code int) *GetRoutesDefault {
 }
 
 /*
-	GetRoutesDefault describes a response with status code -1, with default header values.
+GetRoutesDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/ipam/ipam_client/virtual_private_cloud/update_network_responses.go
+++ b/stackpath/api/ipam/ipam_client/virtual_private_cloud/update_network_responses.go
@@ -59,7 +59,7 @@ func NewUpdateNetworkOK() *UpdateNetworkOK {
 }
 
 /*
-	UpdateNetworkOK describes a response with status code 200, with default header values.
+UpdateNetworkOK describes a response with status code 200, with default header values.
 
 UpdateNetworkOK update network o k
 */
@@ -92,7 +92,7 @@ func NewUpdateNetworkUnauthorized() *UpdateNetworkUnauthorized {
 }
 
 /*
-	UpdateNetworkUnauthorized describes a response with status code 401, with default header values.
+UpdateNetworkUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -125,7 +125,7 @@ func NewUpdateNetworkInternalServerError() *UpdateNetworkInternalServerError {
 }
 
 /*
-	UpdateNetworkInternalServerError describes a response with status code 500, with default header values.
+UpdateNetworkInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -160,7 +160,7 @@ func NewUpdateNetworkDefault(code int) *UpdateNetworkDefault {
 }
 
 /*
-	UpdateNetworkDefault describes a response with status code -1, with default header values.
+UpdateNetworkDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/ipam/ipam_client/virtual_private_cloud/update_network_subnet_responses.go
+++ b/stackpath/api/ipam/ipam_client/virtual_private_cloud/update_network_subnet_responses.go
@@ -59,7 +59,7 @@ func NewUpdateNetworkSubnetOK() *UpdateNetworkSubnetOK {
 }
 
 /*
-	UpdateNetworkSubnetOK describes a response with status code 200, with default header values.
+UpdateNetworkSubnetOK describes a response with status code 200, with default header values.
 
 UpdateNetworkSubnetOK update network subnet o k
 */
@@ -92,7 +92,7 @@ func NewUpdateNetworkSubnetUnauthorized() *UpdateNetworkSubnetUnauthorized {
 }
 
 /*
-	UpdateNetworkSubnetUnauthorized describes a response with status code 401, with default header values.
+UpdateNetworkSubnetUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -125,7 +125,7 @@ func NewUpdateNetworkSubnetInternalServerError() *UpdateNetworkSubnetInternalSer
 }
 
 /*
-	UpdateNetworkSubnetInternalServerError describes a response with status code 500, with default header values.
+UpdateNetworkSubnetInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -160,7 +160,7 @@ func NewUpdateNetworkSubnetDefault(code int) *UpdateNetworkSubnetDefault {
 }
 
 /*
-	UpdateNetworkSubnetDefault describes a response with status code -1, with default header values.
+UpdateNetworkSubnetDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/ipam/ipam_client/virtual_private_cloud/update_route_responses.go
+++ b/stackpath/api/ipam/ipam_client/virtual_private_cloud/update_route_responses.go
@@ -59,7 +59,7 @@ func NewUpdateRouteOK() *UpdateRouteOK {
 }
 
 /*
-	UpdateRouteOK describes a response with status code 200, with default header values.
+UpdateRouteOK describes a response with status code 200, with default header values.
 
 UpdateRouteOK update route o k
 */
@@ -92,7 +92,7 @@ func NewUpdateRouteUnauthorized() *UpdateRouteUnauthorized {
 }
 
 /*
-	UpdateRouteUnauthorized describes a response with status code 401, with default header values.
+UpdateRouteUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -125,7 +125,7 @@ func NewUpdateRouteInternalServerError() *UpdateRouteInternalServerError {
 }
 
 /*
-	UpdateRouteInternalServerError describes a response with status code 500, with default header values.
+UpdateRouteInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -160,7 +160,7 @@ func NewUpdateRouteDefault(code int) *UpdateRouteDefault {
 }
 
 /*
-	UpdateRouteDefault describes a response with status code -1, with default header values.
+UpdateRouteDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/ipam/ipam_client/virtual_private_cloud/virtual_private_cloud_client.go
+++ b/stackpath/api/ipam/ipam_client/virtual_private_cloud/virtual_private_cloud_client.go
@@ -62,7 +62,7 @@ type ClientService interface {
 }
 
 /*
-  CreateNetwork creates a v p c network
+CreateNetwork creates a v p c network
 */
 func (a *Client) CreateNetwork(params *CreateNetworkParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateNetworkOK, error) {
 	// TODO: Validate the params before sending
@@ -100,7 +100,7 @@ func (a *Client) CreateNetwork(params *CreateNetworkParams, authInfo runtime.Cli
 }
 
 /*
-  CreateNetworkSubnet create network subnet API
+CreateNetworkSubnet create network subnet API
 */
 func (a *Client) CreateNetworkSubnet(params *CreateNetworkSubnetParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateNetworkSubnetOK, error) {
 	// TODO: Validate the params before sending
@@ -138,13 +138,15 @@ func (a *Client) CreateNetworkSubnet(params *CreateNetworkSubnetParams, authInfo
 }
 
 /*
-  CreateRoute creates a network route
+	CreateRoute creates a network route
 
-  [block:callout]
-{
-  "type": "danger",
-  "body": "This is an alpha API call and should be considered very unstable. Please do not execute this in a production environment. See our [versioning guidelines](doc:versioning) for more information."
-}
+	[block:callout]
+
+	{
+	  "type": "danger",
+	  "body": "This is an alpha API call and should be considered very unstable. Please do not execute this in a production environment. See our [versioning guidelines](doc:versioning) for more information."
+	}
+
 [/block]
 */
 func (a *Client) CreateRoute(params *CreateRouteParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateRouteOK, error) {
@@ -183,7 +185,7 @@ func (a *Client) CreateRoute(params *CreateRouteParams, authInfo runtime.ClientA
 }
 
 /*
-  DeleteNetwork deletes a v p c network
+DeleteNetwork deletes a v p c network
 */
 func (a *Client) DeleteNetwork(params *DeleteNetworkParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteNetworkNoContent, error) {
 	// TODO: Validate the params before sending
@@ -221,7 +223,7 @@ func (a *Client) DeleteNetwork(params *DeleteNetworkParams, authInfo runtime.Cli
 }
 
 /*
-  DeleteNetworkSubnet delete network subnet API
+DeleteNetworkSubnet delete network subnet API
 */
 func (a *Client) DeleteNetworkSubnet(params *DeleteNetworkSubnetParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteNetworkSubnetNoContent, error) {
 	// TODO: Validate the params before sending
@@ -259,13 +261,15 @@ func (a *Client) DeleteNetworkSubnet(params *DeleteNetworkSubnetParams, authInfo
 }
 
 /*
-  DeleteRoute deletes a network route
+	DeleteRoute deletes a network route
 
-  [block:callout]
-{
-  "type": "danger",
-  "body": "This is an alpha API call and should be considered very unstable. Please do not execute this in a production environment. See our [versioning guidelines](doc:versioning) for more information."
-}
+	[block:callout]
+
+	{
+	  "type": "danger",
+	  "body": "This is an alpha API call and should be considered very unstable. Please do not execute this in a production environment. See our [versioning guidelines](doc:versioning) for more information."
+	}
+
 [/block]
 */
 func (a *Client) DeleteRoute(params *DeleteRouteParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteRouteNoContent, error) {
@@ -304,7 +308,7 @@ func (a *Client) DeleteRoute(params *DeleteRouteParams, authInfo runtime.ClientA
 }
 
 /*
-  GetNetwork gets a v p c network
+GetNetwork gets a v p c network
 */
 func (a *Client) GetNetwork(params *GetNetworkParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetNetworkOK, error) {
 	// TODO: Validate the params before sending
@@ -342,7 +346,7 @@ func (a *Client) GetNetwork(params *GetNetworkParams, authInfo runtime.ClientAut
 }
 
 /*
-  GetNetworkSubnet get network subnet API
+GetNetworkSubnet get network subnet API
 */
 func (a *Client) GetNetworkSubnet(params *GetNetworkSubnetParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetNetworkSubnetOK, error) {
 	// TODO: Validate the params before sending
@@ -380,7 +384,7 @@ func (a *Client) GetNetworkSubnet(params *GetNetworkSubnetParams, authInfo runti
 }
 
 /*
-  GetNetworkSubnets get network subnets API
+GetNetworkSubnets get network subnets API
 */
 func (a *Client) GetNetworkSubnets(params *GetNetworkSubnetsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetNetworkSubnetsOK, error) {
 	// TODO: Validate the params before sending
@@ -418,7 +422,7 @@ func (a *Client) GetNetworkSubnets(params *GetNetworkSubnetsParams, authInfo run
 }
 
 /*
-  GetNetworks gets all v p c networks
+GetNetworks gets all v p c networks
 */
 func (a *Client) GetNetworks(params *GetNetworksParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetNetworksOK, error) {
 	// TODO: Validate the params before sending
@@ -456,13 +460,15 @@ func (a *Client) GetNetworks(params *GetNetworksParams, authInfo runtime.ClientA
 }
 
 /*
-  GetRoute gets a network route
+	GetRoute gets a network route
 
-  [block:callout]
-{
-  "type": "danger",
-  "body": "This is an alpha API call and should be considered very unstable. Please do not execute this in a production environment. See our [versioning guidelines](doc:versioning) for more information."
-}
+	[block:callout]
+
+	{
+	  "type": "danger",
+	  "body": "This is an alpha API call and should be considered very unstable. Please do not execute this in a production environment. See our [versioning guidelines](doc:versioning) for more information."
+	}
+
 [/block]
 */
 func (a *Client) GetRoute(params *GetRouteParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetRouteOK, error) {
@@ -501,13 +507,15 @@ func (a *Client) GetRoute(params *GetRouteParams, authInfo runtime.ClientAuthInf
 }
 
 /*
-  GetRoutes gets all network routes
+	GetRoutes gets all network routes
 
-  [block:callout]
-{
-  "type": "danger",
-  "body": "This is an alpha API call and should be considered very unstable. Please do not execute this in a production environment. See our [versioning guidelines](doc:versioning) for more information."
-}
+	[block:callout]
+
+	{
+	  "type": "danger",
+	  "body": "This is an alpha API call and should be considered very unstable. Please do not execute this in a production environment. See our [versioning guidelines](doc:versioning) for more information."
+	}
+
 [/block]
 */
 func (a *Client) GetRoutes(params *GetRoutesParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetRoutesOK, error) {
@@ -546,9 +554,9 @@ func (a *Client) GetRoutes(params *GetRoutesParams, authInfo runtime.ClientAuthI
 }
 
 /*
-  UpdateNetwork updates a v p c network
+UpdateNetwork updates a v p c network
 
-  Only a network's name may be updated
+Only a network's name may be updated
 */
 func (a *Client) UpdateNetwork(params *UpdateNetworkParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UpdateNetworkOK, error) {
 	// TODO: Validate the params before sending
@@ -586,7 +594,7 @@ func (a *Client) UpdateNetwork(params *UpdateNetworkParams, authInfo runtime.Cli
 }
 
 /*
-  UpdateNetworkSubnet update network subnet API
+UpdateNetworkSubnet update network subnet API
 */
 func (a *Client) UpdateNetworkSubnet(params *UpdateNetworkSubnetParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UpdateNetworkSubnetOK, error) {
 	// TODO: Validate the params before sending
@@ -624,13 +632,15 @@ func (a *Client) UpdateNetworkSubnet(params *UpdateNetworkSubnetParams, authInfo
 }
 
 /*
-  UpdateRoute updates a network route
+	UpdateRoute updates a network route
 
-  [block:callout]
-{
-  "type": "danger",
-  "body": "This is an alpha API call and should be considered very unstable. Please do not execute this in a production environment. See our [versioning guidelines](doc:versioning) for more information."
-}
+	[block:callout]
+
+	{
+	  "type": "danger",
+	  "body": "This is an alpha API call and should be considered very unstable. Please do not execute this in a production environment. See our [versioning guidelines](doc:versioning) for more information."
+	}
+
 [/block]
 */
 func (a *Client) UpdateRoute(params *UpdateRouteParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UpdateRouteOK, error) {

--- a/stackpath/api/ipam/ipam_models/api_status_detail.go
+++ b/stackpath/api/ipam/ipam_models/api_status_detail.go
@@ -30,7 +30,7 @@ type APIStatusDetail interface {
 	AtType() string
 	SetAtType(string)
 
-	// AdditionalProperties in base type should be handled just like regular properties
+	// AdditionalProperties in base type shoud be handled just like regular properties
 	// At this moment, the base type property is pushed down to the subtype
 }
 

--- a/stackpath/api/ipam/ipam_models/route_status_state.go
+++ b/stackpath/api/ipam/ipam_models/route_status_state.go
@@ -15,9 +15,9 @@ import (
 )
 
 // RouteStatusState - ROUTE_STATUS_UNSPECIFIED: Route in this region is in an undefined state
-//  - RUNNING: Route has 1 or more assigned gateways and is correctly configured in this region
-//  - NO_GATEWAY: Route does not have any assigned gateways but is configured in this region
-//  - DELETING: Route is being deleted from the region
+//   - RUNNING: Route has 1 or more assigned gateways and is correctly configured in this region
+//   - NO_GATEWAY: Route does not have any assigned gateways but is configured in this region
+//   - DELETING: Route is being deleted from the region
 //
 // swagger:model RouteStatusState
 type RouteStatusState string

--- a/stackpath/api/ipam/ipam_models/v1_network_policy.go
+++ b/stackpath/api/ipam/ipam_models/v1_network_policy.go
@@ -16,7 +16,7 @@ import (
 
 // V1NetworkPolicy A network policy
 //
-// Network policies define an ACL that applies to one or many workload instances
+// # Network policies define an ACL that applies to one or many workload instances
 //
 // swagger:model v1NetworkPolicy
 type V1NetworkPolicy struct {

--- a/stackpath/api/storage/storage_client/buckets/buckets_client.go
+++ b/stackpath/api/storage/storage_client/buckets/buckets_client.go
@@ -42,7 +42,7 @@ type ClientService interface {
 }
 
 /*
-  CreateBucket creates a bucket under a stack
+CreateBucket creates a bucket under a stack
 */
 func (a *Client) CreateBucket(params *CreateBucketParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateBucketOK, error) {
 	// TODO: Validate the params before sending
@@ -80,7 +80,7 @@ func (a *Client) CreateBucket(params *CreateBucketParams, authInfo runtime.Clien
 }
 
 /*
-  DeleteBucket deletes a given bucket
+DeleteBucket deletes a given bucket
 */
 func (a *Client) DeleteBucket(params *DeleteBucketParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteBucketNoContent, error) {
 	// TODO: Validate the params before sending
@@ -118,7 +118,7 @@ func (a *Client) DeleteBucket(params *DeleteBucketParams, authInfo runtime.Clien
 }
 
 /*
-  GetBucket retrieves a bucket in the storage provider for a given stack
+GetBucket retrieves a bucket in the storage provider for a given stack
 */
 func (a *Client) GetBucket(params *GetBucketParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetBucketOK, error) {
 	// TODO: Validate the params before sending
@@ -156,7 +156,7 @@ func (a *Client) GetBucket(params *GetBucketParams, authInfo runtime.ClientAuthI
 }
 
 /*
-  GetBuckets retrieves all buckets in the storage provider for a given stack
+GetBuckets retrieves all buckets in the storage provider for a given stack
 */
 func (a *Client) GetBuckets(params *GetBucketsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetBucketsOK, error) {
 	// TODO: Validate the params before sending
@@ -194,7 +194,7 @@ func (a *Client) GetBuckets(params *GetBucketsParams, authInfo runtime.ClientAut
 }
 
 /*
-  UpdateBucket updates the name of a bucket
+UpdateBucket updates the name of a bucket
 */
 func (a *Client) UpdateBucket(params *UpdateBucketParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UpdateBucketOK, error) {
 	// TODO: Validate the params before sending

--- a/stackpath/api/storage/storage_client/buckets/create_bucket_responses.go
+++ b/stackpath/api/storage/storage_client/buckets/create_bucket_responses.go
@@ -59,7 +59,7 @@ func NewCreateBucketOK() *CreateBucketOK {
 }
 
 /*
-	CreateBucketOK describes a response with status code 200, with default header values.
+CreateBucketOK describes a response with status code 200, with default header values.
 
 CreateBucketOK create bucket o k
 */
@@ -92,7 +92,7 @@ func NewCreateBucketUnauthorized() *CreateBucketUnauthorized {
 }
 
 /*
-	CreateBucketUnauthorized describes a response with status code 401, with default header values.
+CreateBucketUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -125,7 +125,7 @@ func NewCreateBucketInternalServerError() *CreateBucketInternalServerError {
 }
 
 /*
-	CreateBucketInternalServerError describes a response with status code 500, with default header values.
+CreateBucketInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -160,7 +160,7 @@ func NewCreateBucketDefault(code int) *CreateBucketDefault {
 }
 
 /*
-	CreateBucketDefault describes a response with status code -1, with default header values.
+CreateBucketDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/storage/storage_client/buckets/delete_bucket_parameters.go
+++ b/stackpath/api/storage/storage_client/buckets/delete_bucket_parameters.go
@@ -53,10 +53,12 @@ func NewDeleteBucketParamsWithHTTPClient(client *http.Client) *DeleteBucketParam
 	}
 }
 
-/* DeleteBucketParams contains all the parameters to send to the API endpoint
-   for the delete bucket operation.
+/*
+DeleteBucketParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the delete bucket operation.
+
+	Typically these are written to a http.Request.
 */
 type DeleteBucketParams struct {
 

--- a/stackpath/api/storage/storage_client/buckets/delete_bucket_responses.go
+++ b/stackpath/api/storage/storage_client/buckets/delete_bucket_responses.go
@@ -59,7 +59,7 @@ func NewDeleteBucketNoContent() *DeleteBucketNoContent {
 }
 
 /*
-	DeleteBucketNoContent describes a response with status code 204, with default header values.
+DeleteBucketNoContent describes a response with status code 204, with default header values.
 
 No content
 */
@@ -81,7 +81,7 @@ func NewDeleteBucketUnauthorized() *DeleteBucketUnauthorized {
 }
 
 /*
-	DeleteBucketUnauthorized describes a response with status code 401, with default header values.
+DeleteBucketUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -114,7 +114,7 @@ func NewDeleteBucketInternalServerError() *DeleteBucketInternalServerError {
 }
 
 /*
-	DeleteBucketInternalServerError describes a response with status code 500, with default header values.
+DeleteBucketInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -149,7 +149,7 @@ func NewDeleteBucketDefault(code int) *DeleteBucketDefault {
 }
 
 /*
-	DeleteBucketDefault describes a response with status code -1, with default header values.
+DeleteBucketDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/storage/storage_client/buckets/get_bucket_parameters.go
+++ b/stackpath/api/storage/storage_client/buckets/get_bucket_parameters.go
@@ -52,10 +52,12 @@ func NewGetBucketParamsWithHTTPClient(client *http.Client) *GetBucketParams {
 	}
 }
 
-/* GetBucketParams contains all the parameters to send to the API endpoint
-   for the get bucket operation.
+/*
+GetBucketParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get bucket operation.
+
+	Typically these are written to a http.Request.
 */
 type GetBucketParams struct {
 

--- a/stackpath/api/storage/storage_client/buckets/get_bucket_responses.go
+++ b/stackpath/api/storage/storage_client/buckets/get_bucket_responses.go
@@ -59,7 +59,7 @@ func NewGetBucketOK() *GetBucketOK {
 }
 
 /*
-	GetBucketOK describes a response with status code 200, with default header values.
+GetBucketOK describes a response with status code 200, with default header values.
 
 GetBucketOK get bucket o k
 */
@@ -92,7 +92,7 @@ func NewGetBucketUnauthorized() *GetBucketUnauthorized {
 }
 
 /*
-	GetBucketUnauthorized describes a response with status code 401, with default header values.
+GetBucketUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -125,7 +125,7 @@ func NewGetBucketInternalServerError() *GetBucketInternalServerError {
 }
 
 /*
-	GetBucketInternalServerError describes a response with status code 500, with default header values.
+GetBucketInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -160,7 +160,7 @@ func NewGetBucketDefault(code int) *GetBucketDefault {
 }
 
 /*
-	GetBucketDefault describes a response with status code -1, with default header values.
+GetBucketDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/storage/storage_client/buckets/get_buckets_parameters.go
+++ b/stackpath/api/storage/storage_client/buckets/get_buckets_parameters.go
@@ -52,10 +52,12 @@ func NewGetBucketsParamsWithHTTPClient(client *http.Client) *GetBucketsParams {
 	}
 }
 
-/* GetBucketsParams contains all the parameters to send to the API endpoint
-   for the get buckets operation.
+/*
+GetBucketsParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get buckets operation.
+
+	Typically these are written to a http.Request.
 */
 type GetBucketsParams struct {
 

--- a/stackpath/api/storage/storage_client/buckets/get_buckets_responses.go
+++ b/stackpath/api/storage/storage_client/buckets/get_buckets_responses.go
@@ -59,7 +59,7 @@ func NewGetBucketsOK() *GetBucketsOK {
 }
 
 /*
-	GetBucketsOK describes a response with status code 200, with default header values.
+GetBucketsOK describes a response with status code 200, with default header values.
 
 GetBucketsOK get buckets o k
 */
@@ -92,7 +92,7 @@ func NewGetBucketsUnauthorized() *GetBucketsUnauthorized {
 }
 
 /*
-	GetBucketsUnauthorized describes a response with status code 401, with default header values.
+GetBucketsUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -125,7 +125,7 @@ func NewGetBucketsInternalServerError() *GetBucketsInternalServerError {
 }
 
 /*
-	GetBucketsInternalServerError describes a response with status code 500, with default header values.
+GetBucketsInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -160,7 +160,7 @@ func NewGetBucketsDefault(code int) *GetBucketsDefault {
 }
 
 /*
-	GetBucketsDefault describes a response with status code -1, with default header values.
+GetBucketsDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/storage/storage_client/buckets/update_bucket_responses.go
+++ b/stackpath/api/storage/storage_client/buckets/update_bucket_responses.go
@@ -59,7 +59,7 @@ func NewUpdateBucketOK() *UpdateBucketOK {
 }
 
 /*
-	UpdateBucketOK describes a response with status code 200, with default header values.
+UpdateBucketOK describes a response with status code 200, with default header values.
 
 UpdateBucketOK update bucket o k
 */
@@ -92,7 +92,7 @@ func NewUpdateBucketUnauthorized() *UpdateBucketUnauthorized {
 }
 
 /*
-	UpdateBucketUnauthorized describes a response with status code 401, with default header values.
+UpdateBucketUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -125,7 +125,7 @@ func NewUpdateBucketInternalServerError() *UpdateBucketInternalServerError {
 }
 
 /*
-	UpdateBucketInternalServerError describes a response with status code 500, with default header values.
+UpdateBucketInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -160,7 +160,7 @@ func NewUpdateBucketDefault(code int) *UpdateBucketDefault {
 }
 
 /*
-	UpdateBucketDefault describes a response with status code -1, with default header values.
+UpdateBucketDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/storage/storage_client/metrics/get_bucket_metrics_parameters.go
+++ b/stackpath/api/storage/storage_client/metrics/get_bucket_metrics_parameters.go
@@ -52,10 +52,12 @@ func NewGetBucketMetricsParamsWithHTTPClient(client *http.Client) *GetBucketMetr
 	}
 }
 
-/* GetBucketMetricsParams contains all the parameters to send to the API endpoint
-   for the get bucket metrics operation.
+/*
+GetBucketMetricsParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get bucket metrics operation.
+
+	Typically these are written to a http.Request.
 */
 type GetBucketMetricsParams struct {
 

--- a/stackpath/api/storage/storage_client/metrics/get_bucket_metrics_responses.go
+++ b/stackpath/api/storage/storage_client/metrics/get_bucket_metrics_responses.go
@@ -59,7 +59,7 @@ func NewGetBucketMetricsOK() *GetBucketMetricsOK {
 }
 
 /*
-	GetBucketMetricsOK describes a response with status code 200, with default header values.
+GetBucketMetricsOK describes a response with status code 200, with default header values.
 
 GetBucketMetricsOK get bucket metrics o k
 */
@@ -92,7 +92,7 @@ func NewGetBucketMetricsUnauthorized() *GetBucketMetricsUnauthorized {
 }
 
 /*
-	GetBucketMetricsUnauthorized describes a response with status code 401, with default header values.
+GetBucketMetricsUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -125,7 +125,7 @@ func NewGetBucketMetricsInternalServerError() *GetBucketMetricsInternalServerErr
 }
 
 /*
-	GetBucketMetricsInternalServerError describes a response with status code 500, with default header values.
+GetBucketMetricsInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -160,7 +160,7 @@ func NewGetBucketMetricsDefault(code int) *GetBucketMetricsDefault {
 }
 
 /*
-	GetBucketMetricsDefault describes a response with status code -1, with default header values.
+GetBucketMetricsDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/storage/storage_client/metrics/get_stack_metrics_parameters.go
+++ b/stackpath/api/storage/storage_client/metrics/get_stack_metrics_parameters.go
@@ -52,10 +52,12 @@ func NewGetStackMetricsParamsWithHTTPClient(client *http.Client) *GetStackMetric
 	}
 }
 
-/* GetStackMetricsParams contains all the parameters to send to the API endpoint
-   for the get stack metrics operation.
+/*
+GetStackMetricsParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get stack metrics operation.
+
+	Typically these are written to a http.Request.
 */
 type GetStackMetricsParams struct {
 

--- a/stackpath/api/storage/storage_client/metrics/get_stack_metrics_responses.go
+++ b/stackpath/api/storage/storage_client/metrics/get_stack_metrics_responses.go
@@ -59,7 +59,7 @@ func NewGetStackMetricsOK() *GetStackMetricsOK {
 }
 
 /*
-	GetStackMetricsOK describes a response with status code 200, with default header values.
+GetStackMetricsOK describes a response with status code 200, with default header values.
 
 GetStackMetricsOK get stack metrics o k
 */
@@ -92,7 +92,7 @@ func NewGetStackMetricsUnauthorized() *GetStackMetricsUnauthorized {
 }
 
 /*
-	GetStackMetricsUnauthorized describes a response with status code 401, with default header values.
+GetStackMetricsUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -125,7 +125,7 @@ func NewGetStackMetricsInternalServerError() *GetStackMetricsInternalServerError
 }
 
 /*
-	GetStackMetricsInternalServerError describes a response with status code 500, with default header values.
+GetStackMetricsInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -160,7 +160,7 @@ func NewGetStackMetricsDefault(code int) *GetStackMetricsDefault {
 }
 
 /*
-	GetStackMetricsDefault describes a response with status code -1, with default header values.
+GetStackMetricsDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/storage/storage_client/metrics/metrics_client.go
+++ b/stackpath/api/storage/storage_client/metrics/metrics_client.go
@@ -36,9 +36,10 @@ type ClientService interface {
 }
 
 /*
-  GetBucketMetrics gets all daily utilizations for specific bucket
+	GetBucketMetrics gets all daily utilizations for specific bucket
 
-  When the start & end dates are not provided, the metrics for the last day will be returned.
+	When the start & end dates are not provided, the metrics for the last day will be returned.
+
 The date range used must be at least a day apart, and only beginning times are allowed (e.g. 2019-01-01T00:00:00)
 */
 func (a *Client) GetBucketMetrics(params *GetBucketMetricsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetBucketMetricsOK, error) {
@@ -77,9 +78,10 @@ func (a *Client) GetBucketMetrics(params *GetBucketMetricsParams, authInfo runti
 }
 
 /*
-  GetStackMetrics gets all daily utilizations for all buckets on a stack
+	GetStackMetrics gets all daily utilizations for all buckets on a stack
 
-  When the start & end dates are not provided, the metrics for the last day will be returned.
+	When the start & end dates are not provided, the metrics for the last day will be returned.
+
 The date range used must be at least a day apart, and only beginning times are allowed (e.g. 2019-01-01T00:00:00)
 */
 func (a *Client) GetStackMetrics(params *GetStackMetricsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetStackMetricsOK, error) {

--- a/stackpath/api/storage/storage_client/user_credentials/delete_credential_parameters.go
+++ b/stackpath/api/storage/storage_client/user_credentials/delete_credential_parameters.go
@@ -52,10 +52,12 @@ func NewDeleteCredentialParamsWithHTTPClient(client *http.Client) *DeleteCredent
 	}
 }
 
-/* DeleteCredentialParams contains all the parameters to send to the API endpoint
-   for the delete credential operation.
+/*
+DeleteCredentialParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the delete credential operation.
+
+	Typically these are written to a http.Request.
 */
 type DeleteCredentialParams struct {
 

--- a/stackpath/api/storage/storage_client/user_credentials/delete_credential_responses.go
+++ b/stackpath/api/storage/storage_client/user_credentials/delete_credential_responses.go
@@ -59,7 +59,7 @@ func NewDeleteCredentialNoContent() *DeleteCredentialNoContent {
 }
 
 /*
-	DeleteCredentialNoContent describes a response with status code 204, with default header values.
+DeleteCredentialNoContent describes a response with status code 204, with default header values.
 
 No content
 */
@@ -81,7 +81,7 @@ func NewDeleteCredentialUnauthorized() *DeleteCredentialUnauthorized {
 }
 
 /*
-	DeleteCredentialUnauthorized describes a response with status code 401, with default header values.
+DeleteCredentialUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -114,7 +114,7 @@ func NewDeleteCredentialInternalServerError() *DeleteCredentialInternalServerErr
 }
 
 /*
-	DeleteCredentialInternalServerError describes a response with status code 500, with default header values.
+DeleteCredentialInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -149,7 +149,7 @@ func NewDeleteCredentialDefault(code int) *DeleteCredentialDefault {
 }
 
 /*
-	DeleteCredentialDefault describes a response with status code -1, with default header values.
+DeleteCredentialDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/storage/storage_client/user_credentials/generate_credentials_parameters.go
+++ b/stackpath/api/storage/storage_client/user_credentials/generate_credentials_parameters.go
@@ -52,10 +52,12 @@ func NewGenerateCredentialsParamsWithHTTPClient(client *http.Client) *GenerateCr
 	}
 }
 
-/* GenerateCredentialsParams contains all the parameters to send to the API endpoint
-   for the generate credentials operation.
+/*
+GenerateCredentialsParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the generate credentials operation.
+
+	Typically these are written to a http.Request.
 */
 type GenerateCredentialsParams struct {
 

--- a/stackpath/api/storage/storage_client/user_credentials/generate_credentials_responses.go
+++ b/stackpath/api/storage/storage_client/user_credentials/generate_credentials_responses.go
@@ -59,7 +59,7 @@ func NewGenerateCredentialsOK() *GenerateCredentialsOK {
 }
 
 /*
-	GenerateCredentialsOK describes a response with status code 200, with default header values.
+GenerateCredentialsOK describes a response with status code 200, with default header values.
 
 GenerateCredentialsOK generate credentials o k
 */
@@ -92,7 +92,7 @@ func NewGenerateCredentialsUnauthorized() *GenerateCredentialsUnauthorized {
 }
 
 /*
-	GenerateCredentialsUnauthorized describes a response with status code 401, with default header values.
+GenerateCredentialsUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -125,7 +125,7 @@ func NewGenerateCredentialsInternalServerError() *GenerateCredentialsInternalSer
 }
 
 /*
-	GenerateCredentialsInternalServerError describes a response with status code 500, with default header values.
+GenerateCredentialsInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -160,7 +160,7 @@ func NewGenerateCredentialsDefault(code int) *GenerateCredentialsDefault {
 }
 
 /*
-	GenerateCredentialsDefault describes a response with status code -1, with default header values.
+GenerateCredentialsDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/storage/storage_client/user_credentials/get_credentials_parameters.go
+++ b/stackpath/api/storage/storage_client/user_credentials/get_credentials_parameters.go
@@ -52,10 +52,12 @@ func NewGetCredentialsParamsWithHTTPClient(client *http.Client) *GetCredentialsP
 	}
 }
 
-/* GetCredentialsParams contains all the parameters to send to the API endpoint
-   for the get credentials operation.
+/*
+GetCredentialsParams contains all the parameters to send to the API endpoint
 
-   Typically these are written to a http.Request.
+	for the get credentials operation.
+
+	Typically these are written to a http.Request.
 */
 type GetCredentialsParams struct {
 

--- a/stackpath/api/storage/storage_client/user_credentials/get_credentials_responses.go
+++ b/stackpath/api/storage/storage_client/user_credentials/get_credentials_responses.go
@@ -59,7 +59,7 @@ func NewGetCredentialsOK() *GetCredentialsOK {
 }
 
 /*
-	GetCredentialsOK describes a response with status code 200, with default header values.
+GetCredentialsOK describes a response with status code 200, with default header values.
 
 GetCredentialsOK get credentials o k
 */
@@ -92,7 +92,7 @@ func NewGetCredentialsUnauthorized() *GetCredentialsUnauthorized {
 }
 
 /*
-	GetCredentialsUnauthorized describes a response with status code 401, with default header values.
+GetCredentialsUnauthorized describes a response with status code 401, with default header values.
 
 Returned when an unauthorized request is attempted.
 */
@@ -125,7 +125,7 @@ func NewGetCredentialsInternalServerError() *GetCredentialsInternalServerError {
 }
 
 /*
-	GetCredentialsInternalServerError describes a response with status code 500, with default header values.
+GetCredentialsInternalServerError describes a response with status code 500, with default header values.
 
 Internal server error.
 */
@@ -160,7 +160,7 @@ func NewGetCredentialsDefault(code int) *GetCredentialsDefault {
 }
 
 /*
-	GetCredentialsDefault describes a response with status code -1, with default header values.
+GetCredentialsDefault describes a response with status code -1, with default header values.
 
 Default error structure.
 */

--- a/stackpath/api/storage/storage_client/user_credentials/user_credentials_client.go
+++ b/stackpath/api/storage/storage_client/user_credentials/user_credentials_client.go
@@ -38,7 +38,7 @@ type ClientService interface {
 }
 
 /*
-  DeleteCredential deletes provided storage access credentials for the given user
+DeleteCredential deletes provided storage access credentials for the given user
 */
 func (a *Client) DeleteCredential(params *DeleteCredentialParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteCredentialNoContent, error) {
 	// TODO: Validate the params before sending
@@ -76,9 +76,9 @@ func (a *Client) DeleteCredential(params *DeleteCredentialParams, authInfo runti
 }
 
 /*
-  GenerateCredentials generates storage credentials for the given user
+GenerateCredentials generates storage credentials for the given user
 
-  Generate storage credentials for the given user. Users can only have one set of credentials, so calling this method will generate a new set and invalidate any existing ones.
+Generate storage credentials for the given user. Users can only have one set of credentials, so calling this method will generate a new set and invalidate any existing ones.
 */
 func (a *Client) GenerateCredentials(params *GenerateCredentialsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GenerateCredentialsOK, error) {
 	// TODO: Validate the params before sending
@@ -116,7 +116,7 @@ func (a *Client) GenerateCredentials(params *GenerateCredentialsParams, authInfo
 }
 
 /*
-  GetCredentials gets credentials for a given user
+GetCredentials gets credentials for a given user
 */
 func (a *Client) GetCredentials(params *GetCredentialsParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetCredentialsOK, error) {
 	// TODO: Validate the params before sending

--- a/stackpath/api/storage/storage_models/api_status_detail.go
+++ b/stackpath/api/storage/storage_models/api_status_detail.go
@@ -30,7 +30,7 @@ type APIStatusDetail interface {
 	AtType() string
 	SetAtType(string)
 
-	// AdditionalProperties in base type should be handled just like regular properties
+	// AdditionalProperties in base type shoud be handled just like regular properties
 	// At this moment, the base type property is pushed down to the subtype
 }
 

--- a/stackpath/api/storage/storage_models/storage_bucket_visibility.go
+++ b/stackpath/api/storage/storage_models/storage_bucket_visibility.go
@@ -15,7 +15,7 @@ import (
 )
 
 // StorageBucketVisibility - PRIVATE: The bucket is private and only accessibly with credentials
-//  - PUBLIC: The bucket is public and accessible over the internet
+//   - PUBLIC: The bucket is public and accessible over the internet
 //
 // swagger:model storageBucketVisibility
 type StorageBucketVisibility string

--- a/stackpath/api/workload/workload_client/infrastructure/get_locations_responses.go
+++ b/stackpath/api/workload/workload_client/infrastructure/get_locations_responses.go
@@ -67,44 +67,9 @@ type GetLocationsOK struct {
 	Payload *workload_models.V1GetLocationsResponse
 }
 
-// IsSuccess returns true when this get locations o k response has a 2xx status code
-func (o *GetLocationsOK) IsSuccess() bool {
-	return true
-}
-
-// IsRedirect returns true when this get locations o k response has a 3xx status code
-func (o *GetLocationsOK) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this get locations o k response has a 4xx status code
-func (o *GetLocationsOK) IsClientError() bool {
-	return false
-}
-
-// IsServerError returns true when this get locations o k response has a 5xx status code
-func (o *GetLocationsOK) IsServerError() bool {
-	return false
-}
-
-// IsCode returns true when this get locations o k response a status code equal to that given
-func (o *GetLocationsOK) IsCode(code int) bool {
-	return code == 200
-}
-
-// Code gets the status code for the get locations o k response
-func (o *GetLocationsOK) Code() int {
-	return 200
-}
-
 func (o *GetLocationsOK) Error() string {
 	return fmt.Sprintf("[GET /workload/v1/locations][%d] getLocationsOK  %+v", 200, o.Payload)
 }
-
-func (o *GetLocationsOK) String() string {
-	return fmt.Sprintf("[GET /workload/v1/locations][%d] getLocationsOK  %+v", 200, o.Payload)
-}
-
 func (o *GetLocationsOK) GetPayload() *workload_models.V1GetLocationsResponse {
 	return o.Payload
 }
@@ -135,44 +100,9 @@ type GetLocationsUnauthorized struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this get locations unauthorized response has a 2xx status code
-func (o *GetLocationsUnauthorized) IsSuccess() bool {
-	return false
-}
-
-// IsRedirect returns true when this get locations unauthorized response has a 3xx status code
-func (o *GetLocationsUnauthorized) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this get locations unauthorized response has a 4xx status code
-func (o *GetLocationsUnauthorized) IsClientError() bool {
-	return true
-}
-
-// IsServerError returns true when this get locations unauthorized response has a 5xx status code
-func (o *GetLocationsUnauthorized) IsServerError() bool {
-	return false
-}
-
-// IsCode returns true when this get locations unauthorized response a status code equal to that given
-func (o *GetLocationsUnauthorized) IsCode(code int) bool {
-	return code == 401
-}
-
-// Code gets the status code for the get locations unauthorized response
-func (o *GetLocationsUnauthorized) Code() int {
-	return 401
-}
-
 func (o *GetLocationsUnauthorized) Error() string {
 	return fmt.Sprintf("[GET /workload/v1/locations][%d] getLocationsUnauthorized  %+v", 401, o.Payload)
 }
-
-func (o *GetLocationsUnauthorized) String() string {
-	return fmt.Sprintf("[GET /workload/v1/locations][%d] getLocationsUnauthorized  %+v", 401, o.Payload)
-}
-
 func (o *GetLocationsUnauthorized) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }
@@ -203,44 +133,9 @@ type GetLocationsInternalServerError struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this get locations internal server error response has a 2xx status code
-func (o *GetLocationsInternalServerError) IsSuccess() bool {
-	return false
-}
-
-// IsRedirect returns true when this get locations internal server error response has a 3xx status code
-func (o *GetLocationsInternalServerError) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this get locations internal server error response has a 4xx status code
-func (o *GetLocationsInternalServerError) IsClientError() bool {
-	return false
-}
-
-// IsServerError returns true when this get locations internal server error response has a 5xx status code
-func (o *GetLocationsInternalServerError) IsServerError() bool {
-	return true
-}
-
-// IsCode returns true when this get locations internal server error response a status code equal to that given
-func (o *GetLocationsInternalServerError) IsCode(code int) bool {
-	return code == 500
-}
-
-// Code gets the status code for the get locations internal server error response
-func (o *GetLocationsInternalServerError) Code() int {
-	return 500
-}
-
 func (o *GetLocationsInternalServerError) Error() string {
 	return fmt.Sprintf("[GET /workload/v1/locations][%d] getLocationsInternalServerError  %+v", 500, o.Payload)
 }
-
-func (o *GetLocationsInternalServerError) String() string {
-	return fmt.Sprintf("[GET /workload/v1/locations][%d] getLocationsInternalServerError  %+v", 500, o.Payload)
-}
-
 func (o *GetLocationsInternalServerError) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }
@@ -275,31 +170,6 @@ type GetLocationsDefault struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this get locations default response has a 2xx status code
-func (o *GetLocationsDefault) IsSuccess() bool {
-	return o._statusCode/100 == 2
-}
-
-// IsRedirect returns true when this get locations default response has a 3xx status code
-func (o *GetLocationsDefault) IsRedirect() bool {
-	return o._statusCode/100 == 3
-}
-
-// IsClientError returns true when this get locations default response has a 4xx status code
-func (o *GetLocationsDefault) IsClientError() bool {
-	return o._statusCode/100 == 4
-}
-
-// IsServerError returns true when this get locations default response has a 5xx status code
-func (o *GetLocationsDefault) IsServerError() bool {
-	return o._statusCode/100 == 5
-}
-
-// IsCode returns true when this get locations default response a status code equal to that given
-func (o *GetLocationsDefault) IsCode(code int) bool {
-	return o._statusCode == code
-}
-
 // Code gets the status code for the get locations default response
 func (o *GetLocationsDefault) Code() int {
 	return o._statusCode
@@ -308,11 +178,6 @@ func (o *GetLocationsDefault) Code() int {
 func (o *GetLocationsDefault) Error() string {
 	return fmt.Sprintf("[GET /workload/v1/locations][%d] GetLocations default  %+v", o._statusCode, o.Payload)
 }
-
-func (o *GetLocationsDefault) String() string {
-	return fmt.Sprintf("[GET /workload/v1/locations][%d] GetLocations default  %+v", o._statusCode, o.Payload)
-}
-
 func (o *GetLocationsDefault) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }

--- a/stackpath/api/workload/workload_client/instance/get_workload_instance_initial_password_responses.go
+++ b/stackpath/api/workload/workload_client/instance/get_workload_instance_initial_password_responses.go
@@ -67,44 +67,9 @@ type GetWorkloadInstanceInitialPasswordOK struct {
 	Payload *workload_models.V1GetWorkloadInstanceInitialPasswordResponse
 }
 
-// IsSuccess returns true when this get workload instance initial password o k response has a 2xx status code
-func (o *GetWorkloadInstanceInitialPasswordOK) IsSuccess() bool {
-	return true
-}
-
-// IsRedirect returns true when this get workload instance initial password o k response has a 3xx status code
-func (o *GetWorkloadInstanceInitialPasswordOK) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this get workload instance initial password o k response has a 4xx status code
-func (o *GetWorkloadInstanceInitialPasswordOK) IsClientError() bool {
-	return false
-}
-
-// IsServerError returns true when this get workload instance initial password o k response has a 5xx status code
-func (o *GetWorkloadInstanceInitialPasswordOK) IsServerError() bool {
-	return false
-}
-
-// IsCode returns true when this get workload instance initial password o k response a status code equal to that given
-func (o *GetWorkloadInstanceInitialPasswordOK) IsCode(code int) bool {
-	return code == 200
-}
-
-// Code gets the status code for the get workload instance initial password o k response
-func (o *GetWorkloadInstanceInitialPasswordOK) Code() int {
-	return 200
-}
-
 func (o *GetWorkloadInstanceInitialPasswordOK) Error() string {
 	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/workloads/{workload_id}/instances/{instance_name}/passwords/initial][%d] getWorkloadInstanceInitialPasswordOK  %+v", 200, o.Payload)
 }
-
-func (o *GetWorkloadInstanceInitialPasswordOK) String() string {
-	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/workloads/{workload_id}/instances/{instance_name}/passwords/initial][%d] getWorkloadInstanceInitialPasswordOK  %+v", 200, o.Payload)
-}
-
 func (o *GetWorkloadInstanceInitialPasswordOK) GetPayload() *workload_models.V1GetWorkloadInstanceInitialPasswordResponse {
 	return o.Payload
 }
@@ -135,44 +100,9 @@ type GetWorkloadInstanceInitialPasswordUnauthorized struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this get workload instance initial password unauthorized response has a 2xx status code
-func (o *GetWorkloadInstanceInitialPasswordUnauthorized) IsSuccess() bool {
-	return false
-}
-
-// IsRedirect returns true when this get workload instance initial password unauthorized response has a 3xx status code
-func (o *GetWorkloadInstanceInitialPasswordUnauthorized) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this get workload instance initial password unauthorized response has a 4xx status code
-func (o *GetWorkloadInstanceInitialPasswordUnauthorized) IsClientError() bool {
-	return true
-}
-
-// IsServerError returns true when this get workload instance initial password unauthorized response has a 5xx status code
-func (o *GetWorkloadInstanceInitialPasswordUnauthorized) IsServerError() bool {
-	return false
-}
-
-// IsCode returns true when this get workload instance initial password unauthorized response a status code equal to that given
-func (o *GetWorkloadInstanceInitialPasswordUnauthorized) IsCode(code int) bool {
-	return code == 401
-}
-
-// Code gets the status code for the get workload instance initial password unauthorized response
-func (o *GetWorkloadInstanceInitialPasswordUnauthorized) Code() int {
-	return 401
-}
-
 func (o *GetWorkloadInstanceInitialPasswordUnauthorized) Error() string {
 	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/workloads/{workload_id}/instances/{instance_name}/passwords/initial][%d] getWorkloadInstanceInitialPasswordUnauthorized  %+v", 401, o.Payload)
 }
-
-func (o *GetWorkloadInstanceInitialPasswordUnauthorized) String() string {
-	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/workloads/{workload_id}/instances/{instance_name}/passwords/initial][%d] getWorkloadInstanceInitialPasswordUnauthorized  %+v", 401, o.Payload)
-}
-
 func (o *GetWorkloadInstanceInitialPasswordUnauthorized) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }
@@ -203,44 +133,9 @@ type GetWorkloadInstanceInitialPasswordInternalServerError struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this get workload instance initial password internal server error response has a 2xx status code
-func (o *GetWorkloadInstanceInitialPasswordInternalServerError) IsSuccess() bool {
-	return false
-}
-
-// IsRedirect returns true when this get workload instance initial password internal server error response has a 3xx status code
-func (o *GetWorkloadInstanceInitialPasswordInternalServerError) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this get workload instance initial password internal server error response has a 4xx status code
-func (o *GetWorkloadInstanceInitialPasswordInternalServerError) IsClientError() bool {
-	return false
-}
-
-// IsServerError returns true when this get workload instance initial password internal server error response has a 5xx status code
-func (o *GetWorkloadInstanceInitialPasswordInternalServerError) IsServerError() bool {
-	return true
-}
-
-// IsCode returns true when this get workload instance initial password internal server error response a status code equal to that given
-func (o *GetWorkloadInstanceInitialPasswordInternalServerError) IsCode(code int) bool {
-	return code == 500
-}
-
-// Code gets the status code for the get workload instance initial password internal server error response
-func (o *GetWorkloadInstanceInitialPasswordInternalServerError) Code() int {
-	return 500
-}
-
 func (o *GetWorkloadInstanceInitialPasswordInternalServerError) Error() string {
 	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/workloads/{workload_id}/instances/{instance_name}/passwords/initial][%d] getWorkloadInstanceInitialPasswordInternalServerError  %+v", 500, o.Payload)
 }
-
-func (o *GetWorkloadInstanceInitialPasswordInternalServerError) String() string {
-	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/workloads/{workload_id}/instances/{instance_name}/passwords/initial][%d] getWorkloadInstanceInitialPasswordInternalServerError  %+v", 500, o.Payload)
-}
-
 func (o *GetWorkloadInstanceInitialPasswordInternalServerError) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }
@@ -275,31 +170,6 @@ type GetWorkloadInstanceInitialPasswordDefault struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this get workload instance initial password default response has a 2xx status code
-func (o *GetWorkloadInstanceInitialPasswordDefault) IsSuccess() bool {
-	return o._statusCode/100 == 2
-}
-
-// IsRedirect returns true when this get workload instance initial password default response has a 3xx status code
-func (o *GetWorkloadInstanceInitialPasswordDefault) IsRedirect() bool {
-	return o._statusCode/100 == 3
-}
-
-// IsClientError returns true when this get workload instance initial password default response has a 4xx status code
-func (o *GetWorkloadInstanceInitialPasswordDefault) IsClientError() bool {
-	return o._statusCode/100 == 4
-}
-
-// IsServerError returns true when this get workload instance initial password default response has a 5xx status code
-func (o *GetWorkloadInstanceInitialPasswordDefault) IsServerError() bool {
-	return o._statusCode/100 == 5
-}
-
-// IsCode returns true when this get workload instance initial password default response a status code equal to that given
-func (o *GetWorkloadInstanceInitialPasswordDefault) IsCode(code int) bool {
-	return o._statusCode == code
-}
-
 // Code gets the status code for the get workload instance initial password default response
 func (o *GetWorkloadInstanceInitialPasswordDefault) Code() int {
 	return o._statusCode
@@ -308,11 +178,6 @@ func (o *GetWorkloadInstanceInitialPasswordDefault) Code() int {
 func (o *GetWorkloadInstanceInitialPasswordDefault) Error() string {
 	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/workloads/{workload_id}/instances/{instance_name}/passwords/initial][%d] GetWorkloadInstanceInitialPassword default  %+v", o._statusCode, o.Payload)
 }
-
-func (o *GetWorkloadInstanceInitialPasswordDefault) String() string {
-	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/workloads/{workload_id}/instances/{instance_name}/passwords/initial][%d] GetWorkloadInstanceInitialPassword default  %+v", o._statusCode, o.Payload)
-}
-
 func (o *GetWorkloadInstanceInitialPasswordDefault) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }

--- a/stackpath/api/workload/workload_client/instance_logs/get_logs_responses.go
+++ b/stackpath/api/workload/workload_client/instance_logs/get_logs_responses.go
@@ -67,44 +67,9 @@ type GetLogsOK struct {
 	Payload *workload_models.V1LogChunk
 }
 
-// IsSuccess returns true when this get logs o k response has a 2xx status code
-func (o *GetLogsOK) IsSuccess() bool {
-	return true
-}
-
-// IsRedirect returns true when this get logs o k response has a 3xx status code
-func (o *GetLogsOK) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this get logs o k response has a 4xx status code
-func (o *GetLogsOK) IsClientError() bool {
-	return false
-}
-
-// IsServerError returns true when this get logs o k response has a 5xx status code
-func (o *GetLogsOK) IsServerError() bool {
-	return false
-}
-
-// IsCode returns true when this get logs o k response a status code equal to that given
-func (o *GetLogsOK) IsCode(code int) bool {
-	return code == 200
-}
-
-// Code gets the status code for the get logs o k response
-func (o *GetLogsOK) Code() int {
-	return 200
-}
-
 func (o *GetLogsOK) Error() string {
 	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/workloads/{workload_id}/instances/{instance_name}/logs][%d] getLogsOK  %+v", 200, o.Payload)
 }
-
-func (o *GetLogsOK) String() string {
-	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/workloads/{workload_id}/instances/{instance_name}/logs][%d] getLogsOK  %+v", 200, o.Payload)
-}
-
 func (o *GetLogsOK) GetPayload() *workload_models.V1LogChunk {
 	return o.Payload
 }
@@ -135,44 +100,9 @@ type GetLogsUnauthorized struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this get logs unauthorized response has a 2xx status code
-func (o *GetLogsUnauthorized) IsSuccess() bool {
-	return false
-}
-
-// IsRedirect returns true when this get logs unauthorized response has a 3xx status code
-func (o *GetLogsUnauthorized) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this get logs unauthorized response has a 4xx status code
-func (o *GetLogsUnauthorized) IsClientError() bool {
-	return true
-}
-
-// IsServerError returns true when this get logs unauthorized response has a 5xx status code
-func (o *GetLogsUnauthorized) IsServerError() bool {
-	return false
-}
-
-// IsCode returns true when this get logs unauthorized response a status code equal to that given
-func (o *GetLogsUnauthorized) IsCode(code int) bool {
-	return code == 401
-}
-
-// Code gets the status code for the get logs unauthorized response
-func (o *GetLogsUnauthorized) Code() int {
-	return 401
-}
-
 func (o *GetLogsUnauthorized) Error() string {
 	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/workloads/{workload_id}/instances/{instance_name}/logs][%d] getLogsUnauthorized  %+v", 401, o.Payload)
 }
-
-func (o *GetLogsUnauthorized) String() string {
-	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/workloads/{workload_id}/instances/{instance_name}/logs][%d] getLogsUnauthorized  %+v", 401, o.Payload)
-}
-
 func (o *GetLogsUnauthorized) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }
@@ -203,44 +133,9 @@ type GetLogsInternalServerError struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this get logs internal server error response has a 2xx status code
-func (o *GetLogsInternalServerError) IsSuccess() bool {
-	return false
-}
-
-// IsRedirect returns true when this get logs internal server error response has a 3xx status code
-func (o *GetLogsInternalServerError) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this get logs internal server error response has a 4xx status code
-func (o *GetLogsInternalServerError) IsClientError() bool {
-	return false
-}
-
-// IsServerError returns true when this get logs internal server error response has a 5xx status code
-func (o *GetLogsInternalServerError) IsServerError() bool {
-	return true
-}
-
-// IsCode returns true when this get logs internal server error response a status code equal to that given
-func (o *GetLogsInternalServerError) IsCode(code int) bool {
-	return code == 500
-}
-
-// Code gets the status code for the get logs internal server error response
-func (o *GetLogsInternalServerError) Code() int {
-	return 500
-}
-
 func (o *GetLogsInternalServerError) Error() string {
 	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/workloads/{workload_id}/instances/{instance_name}/logs][%d] getLogsInternalServerError  %+v", 500, o.Payload)
 }
-
-func (o *GetLogsInternalServerError) String() string {
-	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/workloads/{workload_id}/instances/{instance_name}/logs][%d] getLogsInternalServerError  %+v", 500, o.Payload)
-}
-
 func (o *GetLogsInternalServerError) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }
@@ -275,31 +170,6 @@ type GetLogsDefault struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this get logs default response has a 2xx status code
-func (o *GetLogsDefault) IsSuccess() bool {
-	return o._statusCode/100 == 2
-}
-
-// IsRedirect returns true when this get logs default response has a 3xx status code
-func (o *GetLogsDefault) IsRedirect() bool {
-	return o._statusCode/100 == 3
-}
-
-// IsClientError returns true when this get logs default response has a 4xx status code
-func (o *GetLogsDefault) IsClientError() bool {
-	return o._statusCode/100 == 4
-}
-
-// IsServerError returns true when this get logs default response has a 5xx status code
-func (o *GetLogsDefault) IsServerError() bool {
-	return o._statusCode/100 == 5
-}
-
-// IsCode returns true when this get logs default response a status code equal to that given
-func (o *GetLogsDefault) IsCode(code int) bool {
-	return o._statusCode == code
-}
-
 // Code gets the status code for the get logs default response
 func (o *GetLogsDefault) Code() int {
 	return o._statusCode
@@ -308,11 +178,6 @@ func (o *GetLogsDefault) Code() int {
 func (o *GetLogsDefault) Error() string {
 	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/workloads/{workload_id}/instances/{instance_name}/logs][%d] GetLogs default  %+v", o._statusCode, o.Payload)
 }
-
-func (o *GetLogsDefault) String() string {
-	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/workloads/{workload_id}/instances/{instance_name}/logs][%d] GetLogs default  %+v", o._statusCode, o.Payload)
-}
-
 func (o *GetLogsDefault) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }

--- a/stackpath/api/workload/workload_client/instances/get_workload_instance_responses.go
+++ b/stackpath/api/workload/workload_client/instances/get_workload_instance_responses.go
@@ -67,44 +67,9 @@ type GetWorkloadInstanceOK struct {
 	Payload *workload_models.V1GetWorkloadInstanceResponse
 }
 
-// IsSuccess returns true when this get workload instance o k response has a 2xx status code
-func (o *GetWorkloadInstanceOK) IsSuccess() bool {
-	return true
-}
-
-// IsRedirect returns true when this get workload instance o k response has a 3xx status code
-func (o *GetWorkloadInstanceOK) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this get workload instance o k response has a 4xx status code
-func (o *GetWorkloadInstanceOK) IsClientError() bool {
-	return false
-}
-
-// IsServerError returns true when this get workload instance o k response has a 5xx status code
-func (o *GetWorkloadInstanceOK) IsServerError() bool {
-	return false
-}
-
-// IsCode returns true when this get workload instance o k response a status code equal to that given
-func (o *GetWorkloadInstanceOK) IsCode(code int) bool {
-	return code == 200
-}
-
-// Code gets the status code for the get workload instance o k response
-func (o *GetWorkloadInstanceOK) Code() int {
-	return 200
-}
-
 func (o *GetWorkloadInstanceOK) Error() string {
 	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/workloads/{workload_id}/instances/{instance_name}][%d] getWorkloadInstanceOK  %+v", 200, o.Payload)
 }
-
-func (o *GetWorkloadInstanceOK) String() string {
-	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/workloads/{workload_id}/instances/{instance_name}][%d] getWorkloadInstanceOK  %+v", 200, o.Payload)
-}
-
 func (o *GetWorkloadInstanceOK) GetPayload() *workload_models.V1GetWorkloadInstanceResponse {
 	return o.Payload
 }
@@ -135,44 +100,9 @@ type GetWorkloadInstanceUnauthorized struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this get workload instance unauthorized response has a 2xx status code
-func (o *GetWorkloadInstanceUnauthorized) IsSuccess() bool {
-	return false
-}
-
-// IsRedirect returns true when this get workload instance unauthorized response has a 3xx status code
-func (o *GetWorkloadInstanceUnauthorized) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this get workload instance unauthorized response has a 4xx status code
-func (o *GetWorkloadInstanceUnauthorized) IsClientError() bool {
-	return true
-}
-
-// IsServerError returns true when this get workload instance unauthorized response has a 5xx status code
-func (o *GetWorkloadInstanceUnauthorized) IsServerError() bool {
-	return false
-}
-
-// IsCode returns true when this get workload instance unauthorized response a status code equal to that given
-func (o *GetWorkloadInstanceUnauthorized) IsCode(code int) bool {
-	return code == 401
-}
-
-// Code gets the status code for the get workload instance unauthorized response
-func (o *GetWorkloadInstanceUnauthorized) Code() int {
-	return 401
-}
-
 func (o *GetWorkloadInstanceUnauthorized) Error() string {
 	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/workloads/{workload_id}/instances/{instance_name}][%d] getWorkloadInstanceUnauthorized  %+v", 401, o.Payload)
 }
-
-func (o *GetWorkloadInstanceUnauthorized) String() string {
-	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/workloads/{workload_id}/instances/{instance_name}][%d] getWorkloadInstanceUnauthorized  %+v", 401, o.Payload)
-}
-
 func (o *GetWorkloadInstanceUnauthorized) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }
@@ -203,44 +133,9 @@ type GetWorkloadInstanceInternalServerError struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this get workload instance internal server error response has a 2xx status code
-func (o *GetWorkloadInstanceInternalServerError) IsSuccess() bool {
-	return false
-}
-
-// IsRedirect returns true when this get workload instance internal server error response has a 3xx status code
-func (o *GetWorkloadInstanceInternalServerError) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this get workload instance internal server error response has a 4xx status code
-func (o *GetWorkloadInstanceInternalServerError) IsClientError() bool {
-	return false
-}
-
-// IsServerError returns true when this get workload instance internal server error response has a 5xx status code
-func (o *GetWorkloadInstanceInternalServerError) IsServerError() bool {
-	return true
-}
-
-// IsCode returns true when this get workload instance internal server error response a status code equal to that given
-func (o *GetWorkloadInstanceInternalServerError) IsCode(code int) bool {
-	return code == 500
-}
-
-// Code gets the status code for the get workload instance internal server error response
-func (o *GetWorkloadInstanceInternalServerError) Code() int {
-	return 500
-}
-
 func (o *GetWorkloadInstanceInternalServerError) Error() string {
 	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/workloads/{workload_id}/instances/{instance_name}][%d] getWorkloadInstanceInternalServerError  %+v", 500, o.Payload)
 }
-
-func (o *GetWorkloadInstanceInternalServerError) String() string {
-	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/workloads/{workload_id}/instances/{instance_name}][%d] getWorkloadInstanceInternalServerError  %+v", 500, o.Payload)
-}
-
 func (o *GetWorkloadInstanceInternalServerError) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }
@@ -275,31 +170,6 @@ type GetWorkloadInstanceDefault struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this get workload instance default response has a 2xx status code
-func (o *GetWorkloadInstanceDefault) IsSuccess() bool {
-	return o._statusCode/100 == 2
-}
-
-// IsRedirect returns true when this get workload instance default response has a 3xx status code
-func (o *GetWorkloadInstanceDefault) IsRedirect() bool {
-	return o._statusCode/100 == 3
-}
-
-// IsClientError returns true when this get workload instance default response has a 4xx status code
-func (o *GetWorkloadInstanceDefault) IsClientError() bool {
-	return o._statusCode/100 == 4
-}
-
-// IsServerError returns true when this get workload instance default response has a 5xx status code
-func (o *GetWorkloadInstanceDefault) IsServerError() bool {
-	return o._statusCode/100 == 5
-}
-
-// IsCode returns true when this get workload instance default response a status code equal to that given
-func (o *GetWorkloadInstanceDefault) IsCode(code int) bool {
-	return o._statusCode == code
-}
-
 // Code gets the status code for the get workload instance default response
 func (o *GetWorkloadInstanceDefault) Code() int {
 	return o._statusCode
@@ -308,11 +178,6 @@ func (o *GetWorkloadInstanceDefault) Code() int {
 func (o *GetWorkloadInstanceDefault) Error() string {
 	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/workloads/{workload_id}/instances/{instance_name}][%d] GetWorkloadInstance default  %+v", o._statusCode, o.Payload)
 }
-
-func (o *GetWorkloadInstanceDefault) String() string {
-	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/workloads/{workload_id}/instances/{instance_name}][%d] GetWorkloadInstance default  %+v", o._statusCode, o.Payload)
-}
-
 func (o *GetWorkloadInstanceDefault) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }

--- a/stackpath/api/workload/workload_client/instances/get_workload_instances_responses.go
+++ b/stackpath/api/workload/workload_client/instances/get_workload_instances_responses.go
@@ -67,44 +67,9 @@ type GetWorkloadInstancesOK struct {
 	Payload *workload_models.V1GetWorkloadInstancesResponse
 }
 
-// IsSuccess returns true when this get workload instances o k response has a 2xx status code
-func (o *GetWorkloadInstancesOK) IsSuccess() bool {
-	return true
-}
-
-// IsRedirect returns true when this get workload instances o k response has a 3xx status code
-func (o *GetWorkloadInstancesOK) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this get workload instances o k response has a 4xx status code
-func (o *GetWorkloadInstancesOK) IsClientError() bool {
-	return false
-}
-
-// IsServerError returns true when this get workload instances o k response has a 5xx status code
-func (o *GetWorkloadInstancesOK) IsServerError() bool {
-	return false
-}
-
-// IsCode returns true when this get workload instances o k response a status code equal to that given
-func (o *GetWorkloadInstancesOK) IsCode(code int) bool {
-	return code == 200
-}
-
-// Code gets the status code for the get workload instances o k response
-func (o *GetWorkloadInstancesOK) Code() int {
-	return 200
-}
-
 func (o *GetWorkloadInstancesOK) Error() string {
 	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/workloads/{workload_id}/instances][%d] getWorkloadInstancesOK  %+v", 200, o.Payload)
 }
-
-func (o *GetWorkloadInstancesOK) String() string {
-	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/workloads/{workload_id}/instances][%d] getWorkloadInstancesOK  %+v", 200, o.Payload)
-}
-
 func (o *GetWorkloadInstancesOK) GetPayload() *workload_models.V1GetWorkloadInstancesResponse {
 	return o.Payload
 }
@@ -135,44 +100,9 @@ type GetWorkloadInstancesUnauthorized struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this get workload instances unauthorized response has a 2xx status code
-func (o *GetWorkloadInstancesUnauthorized) IsSuccess() bool {
-	return false
-}
-
-// IsRedirect returns true when this get workload instances unauthorized response has a 3xx status code
-func (o *GetWorkloadInstancesUnauthorized) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this get workload instances unauthorized response has a 4xx status code
-func (o *GetWorkloadInstancesUnauthorized) IsClientError() bool {
-	return true
-}
-
-// IsServerError returns true when this get workload instances unauthorized response has a 5xx status code
-func (o *GetWorkloadInstancesUnauthorized) IsServerError() bool {
-	return false
-}
-
-// IsCode returns true when this get workload instances unauthorized response a status code equal to that given
-func (o *GetWorkloadInstancesUnauthorized) IsCode(code int) bool {
-	return code == 401
-}
-
-// Code gets the status code for the get workload instances unauthorized response
-func (o *GetWorkloadInstancesUnauthorized) Code() int {
-	return 401
-}
-
 func (o *GetWorkloadInstancesUnauthorized) Error() string {
 	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/workloads/{workload_id}/instances][%d] getWorkloadInstancesUnauthorized  %+v", 401, o.Payload)
 }
-
-func (o *GetWorkloadInstancesUnauthorized) String() string {
-	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/workloads/{workload_id}/instances][%d] getWorkloadInstancesUnauthorized  %+v", 401, o.Payload)
-}
-
 func (o *GetWorkloadInstancesUnauthorized) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }
@@ -203,44 +133,9 @@ type GetWorkloadInstancesInternalServerError struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this get workload instances internal server error response has a 2xx status code
-func (o *GetWorkloadInstancesInternalServerError) IsSuccess() bool {
-	return false
-}
-
-// IsRedirect returns true when this get workload instances internal server error response has a 3xx status code
-func (o *GetWorkloadInstancesInternalServerError) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this get workload instances internal server error response has a 4xx status code
-func (o *GetWorkloadInstancesInternalServerError) IsClientError() bool {
-	return false
-}
-
-// IsServerError returns true when this get workload instances internal server error response has a 5xx status code
-func (o *GetWorkloadInstancesInternalServerError) IsServerError() bool {
-	return true
-}
-
-// IsCode returns true when this get workload instances internal server error response a status code equal to that given
-func (o *GetWorkloadInstancesInternalServerError) IsCode(code int) bool {
-	return code == 500
-}
-
-// Code gets the status code for the get workload instances internal server error response
-func (o *GetWorkloadInstancesInternalServerError) Code() int {
-	return 500
-}
-
 func (o *GetWorkloadInstancesInternalServerError) Error() string {
 	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/workloads/{workload_id}/instances][%d] getWorkloadInstancesInternalServerError  %+v", 500, o.Payload)
 }
-
-func (o *GetWorkloadInstancesInternalServerError) String() string {
-	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/workloads/{workload_id}/instances][%d] getWorkloadInstancesInternalServerError  %+v", 500, o.Payload)
-}
-
 func (o *GetWorkloadInstancesInternalServerError) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }
@@ -275,31 +170,6 @@ type GetWorkloadInstancesDefault struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this get workload instances default response has a 2xx status code
-func (o *GetWorkloadInstancesDefault) IsSuccess() bool {
-	return o._statusCode/100 == 2
-}
-
-// IsRedirect returns true when this get workload instances default response has a 3xx status code
-func (o *GetWorkloadInstancesDefault) IsRedirect() bool {
-	return o._statusCode/100 == 3
-}
-
-// IsClientError returns true when this get workload instances default response has a 4xx status code
-func (o *GetWorkloadInstancesDefault) IsClientError() bool {
-	return o._statusCode/100 == 4
-}
-
-// IsServerError returns true when this get workload instances default response has a 5xx status code
-func (o *GetWorkloadInstancesDefault) IsServerError() bool {
-	return o._statusCode/100 == 5
-}
-
-// IsCode returns true when this get workload instances default response a status code equal to that given
-func (o *GetWorkloadInstancesDefault) IsCode(code int) bool {
-	return o._statusCode == code
-}
-
 // Code gets the status code for the get workload instances default response
 func (o *GetWorkloadInstancesDefault) Code() int {
 	return o._statusCode
@@ -308,11 +178,6 @@ func (o *GetWorkloadInstancesDefault) Code() int {
 func (o *GetWorkloadInstancesDefault) Error() string {
 	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/workloads/{workload_id}/instances][%d] GetWorkloadInstances default  %+v", o._statusCode, o.Payload)
 }
-
-func (o *GetWorkloadInstancesDefault) String() string {
-	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/workloads/{workload_id}/instances][%d] GetWorkloadInstances default  %+v", o._statusCode, o.Payload)
-}
-
 func (o *GetWorkloadInstancesDefault) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }

--- a/stackpath/api/workload/workload_client/instances/restart_instance_responses.go
+++ b/stackpath/api/workload/workload_client/instances/restart_instance_responses.go
@@ -66,41 +66,7 @@ No content
 type RestartInstanceNoContent struct {
 }
 
-// IsSuccess returns true when this restart instance no content response has a 2xx status code
-func (o *RestartInstanceNoContent) IsSuccess() bool {
-	return true
-}
-
-// IsRedirect returns true when this restart instance no content response has a 3xx status code
-func (o *RestartInstanceNoContent) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this restart instance no content response has a 4xx status code
-func (o *RestartInstanceNoContent) IsClientError() bool {
-	return false
-}
-
-// IsServerError returns true when this restart instance no content response has a 5xx status code
-func (o *RestartInstanceNoContent) IsServerError() bool {
-	return false
-}
-
-// IsCode returns true when this restart instance no content response a status code equal to that given
-func (o *RestartInstanceNoContent) IsCode(code int) bool {
-	return code == 204
-}
-
-// Code gets the status code for the restart instance no content response
-func (o *RestartInstanceNoContent) Code() int {
-	return 204
-}
-
 func (o *RestartInstanceNoContent) Error() string {
-	return fmt.Sprintf("[POST /workload/v1/stacks/{stack_id}/workloads/{workload_id}/instances/{instance_name}/power/restart][%d] restartInstanceNoContent ", 204)
-}
-
-func (o *RestartInstanceNoContent) String() string {
 	return fmt.Sprintf("[POST /workload/v1/stacks/{stack_id}/workloads/{workload_id}/instances/{instance_name}/power/restart][%d] restartInstanceNoContent ", 204)
 }
 
@@ -123,44 +89,9 @@ type RestartInstanceUnauthorized struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this restart instance unauthorized response has a 2xx status code
-func (o *RestartInstanceUnauthorized) IsSuccess() bool {
-	return false
-}
-
-// IsRedirect returns true when this restart instance unauthorized response has a 3xx status code
-func (o *RestartInstanceUnauthorized) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this restart instance unauthorized response has a 4xx status code
-func (o *RestartInstanceUnauthorized) IsClientError() bool {
-	return true
-}
-
-// IsServerError returns true when this restart instance unauthorized response has a 5xx status code
-func (o *RestartInstanceUnauthorized) IsServerError() bool {
-	return false
-}
-
-// IsCode returns true when this restart instance unauthorized response a status code equal to that given
-func (o *RestartInstanceUnauthorized) IsCode(code int) bool {
-	return code == 401
-}
-
-// Code gets the status code for the restart instance unauthorized response
-func (o *RestartInstanceUnauthorized) Code() int {
-	return 401
-}
-
 func (o *RestartInstanceUnauthorized) Error() string {
 	return fmt.Sprintf("[POST /workload/v1/stacks/{stack_id}/workloads/{workload_id}/instances/{instance_name}/power/restart][%d] restartInstanceUnauthorized  %+v", 401, o.Payload)
 }
-
-func (o *RestartInstanceUnauthorized) String() string {
-	return fmt.Sprintf("[POST /workload/v1/stacks/{stack_id}/workloads/{workload_id}/instances/{instance_name}/power/restart][%d] restartInstanceUnauthorized  %+v", 401, o.Payload)
-}
-
 func (o *RestartInstanceUnauthorized) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }
@@ -191,44 +122,9 @@ type RestartInstanceInternalServerError struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this restart instance internal server error response has a 2xx status code
-func (o *RestartInstanceInternalServerError) IsSuccess() bool {
-	return false
-}
-
-// IsRedirect returns true when this restart instance internal server error response has a 3xx status code
-func (o *RestartInstanceInternalServerError) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this restart instance internal server error response has a 4xx status code
-func (o *RestartInstanceInternalServerError) IsClientError() bool {
-	return false
-}
-
-// IsServerError returns true when this restart instance internal server error response has a 5xx status code
-func (o *RestartInstanceInternalServerError) IsServerError() bool {
-	return true
-}
-
-// IsCode returns true when this restart instance internal server error response a status code equal to that given
-func (o *RestartInstanceInternalServerError) IsCode(code int) bool {
-	return code == 500
-}
-
-// Code gets the status code for the restart instance internal server error response
-func (o *RestartInstanceInternalServerError) Code() int {
-	return 500
-}
-
 func (o *RestartInstanceInternalServerError) Error() string {
 	return fmt.Sprintf("[POST /workload/v1/stacks/{stack_id}/workloads/{workload_id}/instances/{instance_name}/power/restart][%d] restartInstanceInternalServerError  %+v", 500, o.Payload)
 }
-
-func (o *RestartInstanceInternalServerError) String() string {
-	return fmt.Sprintf("[POST /workload/v1/stacks/{stack_id}/workloads/{workload_id}/instances/{instance_name}/power/restart][%d] restartInstanceInternalServerError  %+v", 500, o.Payload)
-}
-
 func (o *RestartInstanceInternalServerError) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }
@@ -263,31 +159,6 @@ type RestartInstanceDefault struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this restart instance default response has a 2xx status code
-func (o *RestartInstanceDefault) IsSuccess() bool {
-	return o._statusCode/100 == 2
-}
-
-// IsRedirect returns true when this restart instance default response has a 3xx status code
-func (o *RestartInstanceDefault) IsRedirect() bool {
-	return o._statusCode/100 == 3
-}
-
-// IsClientError returns true when this restart instance default response has a 4xx status code
-func (o *RestartInstanceDefault) IsClientError() bool {
-	return o._statusCode/100 == 4
-}
-
-// IsServerError returns true when this restart instance default response has a 5xx status code
-func (o *RestartInstanceDefault) IsServerError() bool {
-	return o._statusCode/100 == 5
-}
-
-// IsCode returns true when this restart instance default response a status code equal to that given
-func (o *RestartInstanceDefault) IsCode(code int) bool {
-	return o._statusCode == code
-}
-
 // Code gets the status code for the restart instance default response
 func (o *RestartInstanceDefault) Code() int {
 	return o._statusCode
@@ -296,11 +167,6 @@ func (o *RestartInstanceDefault) Code() int {
 func (o *RestartInstanceDefault) Error() string {
 	return fmt.Sprintf("[POST /workload/v1/stacks/{stack_id}/workloads/{workload_id}/instances/{instance_name}/power/restart][%d] RestartInstance default  %+v", o._statusCode, o.Payload)
 }
-
-func (o *RestartInstanceDefault) String() string {
-	return fmt.Sprintf("[POST /workload/v1/stacks/{stack_id}/workloads/{workload_id}/instances/{instance_name}/power/restart][%d] RestartInstance default  %+v", o._statusCode, o.Payload)
-}
-
 func (o *RestartInstanceDefault) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }

--- a/stackpath/api/workload/workload_client/metrics/get_metrics_responses.go
+++ b/stackpath/api/workload/workload_client/metrics/get_metrics_responses.go
@@ -67,44 +67,9 @@ type GetMetricsOK struct {
 	Payload *workload_models.PrometheusMetrics
 }
 
-// IsSuccess returns true when this get metrics o k response has a 2xx status code
-func (o *GetMetricsOK) IsSuccess() bool {
-	return true
-}
-
-// IsRedirect returns true when this get metrics o k response has a 3xx status code
-func (o *GetMetricsOK) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this get metrics o k response has a 4xx status code
-func (o *GetMetricsOK) IsClientError() bool {
-	return false
-}
-
-// IsServerError returns true when this get metrics o k response has a 5xx status code
-func (o *GetMetricsOK) IsServerError() bool {
-	return false
-}
-
-// IsCode returns true when this get metrics o k response a status code equal to that given
-func (o *GetMetricsOK) IsCode(code int) bool {
-	return code == 200
-}
-
-// Code gets the status code for the get metrics o k response
-func (o *GetMetricsOK) Code() int {
-	return 200
-}
-
 func (o *GetMetricsOK) Error() string {
 	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/metrics][%d] getMetricsOK  %+v", 200, o.Payload)
 }
-
-func (o *GetMetricsOK) String() string {
-	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/metrics][%d] getMetricsOK  %+v", 200, o.Payload)
-}
-
 func (o *GetMetricsOK) GetPayload() *workload_models.PrometheusMetrics {
 	return o.Payload
 }
@@ -135,44 +100,9 @@ type GetMetricsUnauthorized struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this get metrics unauthorized response has a 2xx status code
-func (o *GetMetricsUnauthorized) IsSuccess() bool {
-	return false
-}
-
-// IsRedirect returns true when this get metrics unauthorized response has a 3xx status code
-func (o *GetMetricsUnauthorized) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this get metrics unauthorized response has a 4xx status code
-func (o *GetMetricsUnauthorized) IsClientError() bool {
-	return true
-}
-
-// IsServerError returns true when this get metrics unauthorized response has a 5xx status code
-func (o *GetMetricsUnauthorized) IsServerError() bool {
-	return false
-}
-
-// IsCode returns true when this get metrics unauthorized response a status code equal to that given
-func (o *GetMetricsUnauthorized) IsCode(code int) bool {
-	return code == 401
-}
-
-// Code gets the status code for the get metrics unauthorized response
-func (o *GetMetricsUnauthorized) Code() int {
-	return 401
-}
-
 func (o *GetMetricsUnauthorized) Error() string {
 	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/metrics][%d] getMetricsUnauthorized  %+v", 401, o.Payload)
 }
-
-func (o *GetMetricsUnauthorized) String() string {
-	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/metrics][%d] getMetricsUnauthorized  %+v", 401, o.Payload)
-}
-
 func (o *GetMetricsUnauthorized) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }
@@ -203,44 +133,9 @@ type GetMetricsInternalServerError struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this get metrics internal server error response has a 2xx status code
-func (o *GetMetricsInternalServerError) IsSuccess() bool {
-	return false
-}
-
-// IsRedirect returns true when this get metrics internal server error response has a 3xx status code
-func (o *GetMetricsInternalServerError) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this get metrics internal server error response has a 4xx status code
-func (o *GetMetricsInternalServerError) IsClientError() bool {
-	return false
-}
-
-// IsServerError returns true when this get metrics internal server error response has a 5xx status code
-func (o *GetMetricsInternalServerError) IsServerError() bool {
-	return true
-}
-
-// IsCode returns true when this get metrics internal server error response a status code equal to that given
-func (o *GetMetricsInternalServerError) IsCode(code int) bool {
-	return code == 500
-}
-
-// Code gets the status code for the get metrics internal server error response
-func (o *GetMetricsInternalServerError) Code() int {
-	return 500
-}
-
 func (o *GetMetricsInternalServerError) Error() string {
 	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/metrics][%d] getMetricsInternalServerError  %+v", 500, o.Payload)
 }
-
-func (o *GetMetricsInternalServerError) String() string {
-	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/metrics][%d] getMetricsInternalServerError  %+v", 500, o.Payload)
-}
-
 func (o *GetMetricsInternalServerError) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }
@@ -275,31 +170,6 @@ type GetMetricsDefault struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this get metrics default response has a 2xx status code
-func (o *GetMetricsDefault) IsSuccess() bool {
-	return o._statusCode/100 == 2
-}
-
-// IsRedirect returns true when this get metrics default response has a 3xx status code
-func (o *GetMetricsDefault) IsRedirect() bool {
-	return o._statusCode/100 == 3
-}
-
-// IsClientError returns true when this get metrics default response has a 4xx status code
-func (o *GetMetricsDefault) IsClientError() bool {
-	return o._statusCode/100 == 4
-}
-
-// IsServerError returns true when this get metrics default response has a 5xx status code
-func (o *GetMetricsDefault) IsServerError() bool {
-	return o._statusCode/100 == 5
-}
-
-// IsCode returns true when this get metrics default response a status code equal to that given
-func (o *GetMetricsDefault) IsCode(code int) bool {
-	return o._statusCode == code
-}
-
 // Code gets the status code for the get metrics default response
 func (o *GetMetricsDefault) Code() int {
 	return o._statusCode
@@ -308,11 +178,6 @@ func (o *GetMetricsDefault) Code() int {
 func (o *GetMetricsDefault) Error() string {
 	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/metrics][%d] GetMetrics default  %+v", o._statusCode, o.Payload)
 }
-
-func (o *GetMetricsDefault) String() string {
-	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/metrics][%d] GetMetrics default  %+v", o._statusCode, o.Payload)
-}
-
 func (o *GetMetricsDefault) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }

--- a/stackpath/api/workload/workload_client/virtual_machine_images/create_image_responses.go
+++ b/stackpath/api/workload/workload_client/virtual_machine_images/create_image_responses.go
@@ -67,44 +67,9 @@ type CreateImageOK struct {
 	Payload *workload_models.V1CreateImageResponse
 }
 
-// IsSuccess returns true when this create image o k response has a 2xx status code
-func (o *CreateImageOK) IsSuccess() bool {
-	return true
-}
-
-// IsRedirect returns true when this create image o k response has a 3xx status code
-func (o *CreateImageOK) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this create image o k response has a 4xx status code
-func (o *CreateImageOK) IsClientError() bool {
-	return false
-}
-
-// IsServerError returns true when this create image o k response has a 5xx status code
-func (o *CreateImageOK) IsServerError() bool {
-	return false
-}
-
-// IsCode returns true when this create image o k response a status code equal to that given
-func (o *CreateImageOK) IsCode(code int) bool {
-	return code == 200
-}
-
-// Code gets the status code for the create image o k response
-func (o *CreateImageOK) Code() int {
-	return 200
-}
-
 func (o *CreateImageOK) Error() string {
 	return fmt.Sprintf("[POST /workload/v1/stacks/{stack_id}/images/{image_family}/{image_tag}][%d] createImageOK  %+v", 200, o.Payload)
 }
-
-func (o *CreateImageOK) String() string {
-	return fmt.Sprintf("[POST /workload/v1/stacks/{stack_id}/images/{image_family}/{image_tag}][%d] createImageOK  %+v", 200, o.Payload)
-}
-
 func (o *CreateImageOK) GetPayload() *workload_models.V1CreateImageResponse {
 	return o.Payload
 }
@@ -135,44 +100,9 @@ type CreateImageUnauthorized struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this create image unauthorized response has a 2xx status code
-func (o *CreateImageUnauthorized) IsSuccess() bool {
-	return false
-}
-
-// IsRedirect returns true when this create image unauthorized response has a 3xx status code
-func (o *CreateImageUnauthorized) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this create image unauthorized response has a 4xx status code
-func (o *CreateImageUnauthorized) IsClientError() bool {
-	return true
-}
-
-// IsServerError returns true when this create image unauthorized response has a 5xx status code
-func (o *CreateImageUnauthorized) IsServerError() bool {
-	return false
-}
-
-// IsCode returns true when this create image unauthorized response a status code equal to that given
-func (o *CreateImageUnauthorized) IsCode(code int) bool {
-	return code == 401
-}
-
-// Code gets the status code for the create image unauthorized response
-func (o *CreateImageUnauthorized) Code() int {
-	return 401
-}
-
 func (o *CreateImageUnauthorized) Error() string {
 	return fmt.Sprintf("[POST /workload/v1/stacks/{stack_id}/images/{image_family}/{image_tag}][%d] createImageUnauthorized  %+v", 401, o.Payload)
 }
-
-func (o *CreateImageUnauthorized) String() string {
-	return fmt.Sprintf("[POST /workload/v1/stacks/{stack_id}/images/{image_family}/{image_tag}][%d] createImageUnauthorized  %+v", 401, o.Payload)
-}
-
 func (o *CreateImageUnauthorized) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }
@@ -203,44 +133,9 @@ type CreateImageInternalServerError struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this create image internal server error response has a 2xx status code
-func (o *CreateImageInternalServerError) IsSuccess() bool {
-	return false
-}
-
-// IsRedirect returns true when this create image internal server error response has a 3xx status code
-func (o *CreateImageInternalServerError) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this create image internal server error response has a 4xx status code
-func (o *CreateImageInternalServerError) IsClientError() bool {
-	return false
-}
-
-// IsServerError returns true when this create image internal server error response has a 5xx status code
-func (o *CreateImageInternalServerError) IsServerError() bool {
-	return true
-}
-
-// IsCode returns true when this create image internal server error response a status code equal to that given
-func (o *CreateImageInternalServerError) IsCode(code int) bool {
-	return code == 500
-}
-
-// Code gets the status code for the create image internal server error response
-func (o *CreateImageInternalServerError) Code() int {
-	return 500
-}
-
 func (o *CreateImageInternalServerError) Error() string {
 	return fmt.Sprintf("[POST /workload/v1/stacks/{stack_id}/images/{image_family}/{image_tag}][%d] createImageInternalServerError  %+v", 500, o.Payload)
 }
-
-func (o *CreateImageInternalServerError) String() string {
-	return fmt.Sprintf("[POST /workload/v1/stacks/{stack_id}/images/{image_family}/{image_tag}][%d] createImageInternalServerError  %+v", 500, o.Payload)
-}
-
 func (o *CreateImageInternalServerError) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }
@@ -275,31 +170,6 @@ type CreateImageDefault struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this create image default response has a 2xx status code
-func (o *CreateImageDefault) IsSuccess() bool {
-	return o._statusCode/100 == 2
-}
-
-// IsRedirect returns true when this create image default response has a 3xx status code
-func (o *CreateImageDefault) IsRedirect() bool {
-	return o._statusCode/100 == 3
-}
-
-// IsClientError returns true when this create image default response has a 4xx status code
-func (o *CreateImageDefault) IsClientError() bool {
-	return o._statusCode/100 == 4
-}
-
-// IsServerError returns true when this create image default response has a 5xx status code
-func (o *CreateImageDefault) IsServerError() bool {
-	return o._statusCode/100 == 5
-}
-
-// IsCode returns true when this create image default response a status code equal to that given
-func (o *CreateImageDefault) IsCode(code int) bool {
-	return o._statusCode == code
-}
-
 // Code gets the status code for the create image default response
 func (o *CreateImageDefault) Code() int {
 	return o._statusCode
@@ -308,11 +178,6 @@ func (o *CreateImageDefault) Code() int {
 func (o *CreateImageDefault) Error() string {
 	return fmt.Sprintf("[POST /workload/v1/stacks/{stack_id}/images/{image_family}/{image_tag}][%d] CreateImage default  %+v", o._statusCode, o.Payload)
 }
-
-func (o *CreateImageDefault) String() string {
-	return fmt.Sprintf("[POST /workload/v1/stacks/{stack_id}/images/{image_family}/{image_tag}][%d] CreateImage default  %+v", o._statusCode, o.Payload)
-}
-
 func (o *CreateImageDefault) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }

--- a/stackpath/api/workload/workload_client/virtual_machine_images/delete_image_responses.go
+++ b/stackpath/api/workload/workload_client/virtual_machine_images/delete_image_responses.go
@@ -66,41 +66,7 @@ No content
 type DeleteImageNoContent struct {
 }
 
-// IsSuccess returns true when this delete image no content response has a 2xx status code
-func (o *DeleteImageNoContent) IsSuccess() bool {
-	return true
-}
-
-// IsRedirect returns true when this delete image no content response has a 3xx status code
-func (o *DeleteImageNoContent) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this delete image no content response has a 4xx status code
-func (o *DeleteImageNoContent) IsClientError() bool {
-	return false
-}
-
-// IsServerError returns true when this delete image no content response has a 5xx status code
-func (o *DeleteImageNoContent) IsServerError() bool {
-	return false
-}
-
-// IsCode returns true when this delete image no content response a status code equal to that given
-func (o *DeleteImageNoContent) IsCode(code int) bool {
-	return code == 204
-}
-
-// Code gets the status code for the delete image no content response
-func (o *DeleteImageNoContent) Code() int {
-	return 204
-}
-
 func (o *DeleteImageNoContent) Error() string {
-	return fmt.Sprintf("[DELETE /workload/v1/stacks/{stack_id}/images/{image_family}/{image_tag}][%d] deleteImageNoContent ", 204)
-}
-
-func (o *DeleteImageNoContent) String() string {
 	return fmt.Sprintf("[DELETE /workload/v1/stacks/{stack_id}/images/{image_family}/{image_tag}][%d] deleteImageNoContent ", 204)
 }
 
@@ -123,44 +89,9 @@ type DeleteImageUnauthorized struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this delete image unauthorized response has a 2xx status code
-func (o *DeleteImageUnauthorized) IsSuccess() bool {
-	return false
-}
-
-// IsRedirect returns true when this delete image unauthorized response has a 3xx status code
-func (o *DeleteImageUnauthorized) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this delete image unauthorized response has a 4xx status code
-func (o *DeleteImageUnauthorized) IsClientError() bool {
-	return true
-}
-
-// IsServerError returns true when this delete image unauthorized response has a 5xx status code
-func (o *DeleteImageUnauthorized) IsServerError() bool {
-	return false
-}
-
-// IsCode returns true when this delete image unauthorized response a status code equal to that given
-func (o *DeleteImageUnauthorized) IsCode(code int) bool {
-	return code == 401
-}
-
-// Code gets the status code for the delete image unauthorized response
-func (o *DeleteImageUnauthorized) Code() int {
-	return 401
-}
-
 func (o *DeleteImageUnauthorized) Error() string {
 	return fmt.Sprintf("[DELETE /workload/v1/stacks/{stack_id}/images/{image_family}/{image_tag}][%d] deleteImageUnauthorized  %+v", 401, o.Payload)
 }
-
-func (o *DeleteImageUnauthorized) String() string {
-	return fmt.Sprintf("[DELETE /workload/v1/stacks/{stack_id}/images/{image_family}/{image_tag}][%d] deleteImageUnauthorized  %+v", 401, o.Payload)
-}
-
 func (o *DeleteImageUnauthorized) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }
@@ -191,44 +122,9 @@ type DeleteImageInternalServerError struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this delete image internal server error response has a 2xx status code
-func (o *DeleteImageInternalServerError) IsSuccess() bool {
-	return false
-}
-
-// IsRedirect returns true when this delete image internal server error response has a 3xx status code
-func (o *DeleteImageInternalServerError) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this delete image internal server error response has a 4xx status code
-func (o *DeleteImageInternalServerError) IsClientError() bool {
-	return false
-}
-
-// IsServerError returns true when this delete image internal server error response has a 5xx status code
-func (o *DeleteImageInternalServerError) IsServerError() bool {
-	return true
-}
-
-// IsCode returns true when this delete image internal server error response a status code equal to that given
-func (o *DeleteImageInternalServerError) IsCode(code int) bool {
-	return code == 500
-}
-
-// Code gets the status code for the delete image internal server error response
-func (o *DeleteImageInternalServerError) Code() int {
-	return 500
-}
-
 func (o *DeleteImageInternalServerError) Error() string {
 	return fmt.Sprintf("[DELETE /workload/v1/stacks/{stack_id}/images/{image_family}/{image_tag}][%d] deleteImageInternalServerError  %+v", 500, o.Payload)
 }
-
-func (o *DeleteImageInternalServerError) String() string {
-	return fmt.Sprintf("[DELETE /workload/v1/stacks/{stack_id}/images/{image_family}/{image_tag}][%d] deleteImageInternalServerError  %+v", 500, o.Payload)
-}
-
 func (o *DeleteImageInternalServerError) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }
@@ -263,31 +159,6 @@ type DeleteImageDefault struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this delete image default response has a 2xx status code
-func (o *DeleteImageDefault) IsSuccess() bool {
-	return o._statusCode/100 == 2
-}
-
-// IsRedirect returns true when this delete image default response has a 3xx status code
-func (o *DeleteImageDefault) IsRedirect() bool {
-	return o._statusCode/100 == 3
-}
-
-// IsClientError returns true when this delete image default response has a 4xx status code
-func (o *DeleteImageDefault) IsClientError() bool {
-	return o._statusCode/100 == 4
-}
-
-// IsServerError returns true when this delete image default response has a 5xx status code
-func (o *DeleteImageDefault) IsServerError() bool {
-	return o._statusCode/100 == 5
-}
-
-// IsCode returns true when this delete image default response a status code equal to that given
-func (o *DeleteImageDefault) IsCode(code int) bool {
-	return o._statusCode == code
-}
-
 // Code gets the status code for the delete image default response
 func (o *DeleteImageDefault) Code() int {
 	return o._statusCode
@@ -296,11 +167,6 @@ func (o *DeleteImageDefault) Code() int {
 func (o *DeleteImageDefault) Error() string {
 	return fmt.Sprintf("[DELETE /workload/v1/stacks/{stack_id}/images/{image_family}/{image_tag}][%d] DeleteImage default  %+v", o._statusCode, o.Payload)
 }
-
-func (o *DeleteImageDefault) String() string {
-	return fmt.Sprintf("[DELETE /workload/v1/stacks/{stack_id}/images/{image_family}/{image_tag}][%d] DeleteImage default  %+v", o._statusCode, o.Payload)
-}
-
 func (o *DeleteImageDefault) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }

--- a/stackpath/api/workload/workload_client/virtual_machine_images/delete_images_for_family_responses.go
+++ b/stackpath/api/workload/workload_client/virtual_machine_images/delete_images_for_family_responses.go
@@ -66,41 +66,7 @@ No content
 type DeleteImagesForFamilyNoContent struct {
 }
 
-// IsSuccess returns true when this delete images for family no content response has a 2xx status code
-func (o *DeleteImagesForFamilyNoContent) IsSuccess() bool {
-	return true
-}
-
-// IsRedirect returns true when this delete images for family no content response has a 3xx status code
-func (o *DeleteImagesForFamilyNoContent) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this delete images for family no content response has a 4xx status code
-func (o *DeleteImagesForFamilyNoContent) IsClientError() bool {
-	return false
-}
-
-// IsServerError returns true when this delete images for family no content response has a 5xx status code
-func (o *DeleteImagesForFamilyNoContent) IsServerError() bool {
-	return false
-}
-
-// IsCode returns true when this delete images for family no content response a status code equal to that given
-func (o *DeleteImagesForFamilyNoContent) IsCode(code int) bool {
-	return code == 204
-}
-
-// Code gets the status code for the delete images for family no content response
-func (o *DeleteImagesForFamilyNoContent) Code() int {
-	return 204
-}
-
 func (o *DeleteImagesForFamilyNoContent) Error() string {
-	return fmt.Sprintf("[DELETE /workload/v1/stacks/{stack_id}/images/{image_family}][%d] deleteImagesForFamilyNoContent ", 204)
-}
-
-func (o *DeleteImagesForFamilyNoContent) String() string {
 	return fmt.Sprintf("[DELETE /workload/v1/stacks/{stack_id}/images/{image_family}][%d] deleteImagesForFamilyNoContent ", 204)
 }
 
@@ -123,44 +89,9 @@ type DeleteImagesForFamilyUnauthorized struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this delete images for family unauthorized response has a 2xx status code
-func (o *DeleteImagesForFamilyUnauthorized) IsSuccess() bool {
-	return false
-}
-
-// IsRedirect returns true when this delete images for family unauthorized response has a 3xx status code
-func (o *DeleteImagesForFamilyUnauthorized) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this delete images for family unauthorized response has a 4xx status code
-func (o *DeleteImagesForFamilyUnauthorized) IsClientError() bool {
-	return true
-}
-
-// IsServerError returns true when this delete images for family unauthorized response has a 5xx status code
-func (o *DeleteImagesForFamilyUnauthorized) IsServerError() bool {
-	return false
-}
-
-// IsCode returns true when this delete images for family unauthorized response a status code equal to that given
-func (o *DeleteImagesForFamilyUnauthorized) IsCode(code int) bool {
-	return code == 401
-}
-
-// Code gets the status code for the delete images for family unauthorized response
-func (o *DeleteImagesForFamilyUnauthorized) Code() int {
-	return 401
-}
-
 func (o *DeleteImagesForFamilyUnauthorized) Error() string {
 	return fmt.Sprintf("[DELETE /workload/v1/stacks/{stack_id}/images/{image_family}][%d] deleteImagesForFamilyUnauthorized  %+v", 401, o.Payload)
 }
-
-func (o *DeleteImagesForFamilyUnauthorized) String() string {
-	return fmt.Sprintf("[DELETE /workload/v1/stacks/{stack_id}/images/{image_family}][%d] deleteImagesForFamilyUnauthorized  %+v", 401, o.Payload)
-}
-
 func (o *DeleteImagesForFamilyUnauthorized) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }
@@ -191,44 +122,9 @@ type DeleteImagesForFamilyInternalServerError struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this delete images for family internal server error response has a 2xx status code
-func (o *DeleteImagesForFamilyInternalServerError) IsSuccess() bool {
-	return false
-}
-
-// IsRedirect returns true when this delete images for family internal server error response has a 3xx status code
-func (o *DeleteImagesForFamilyInternalServerError) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this delete images for family internal server error response has a 4xx status code
-func (o *DeleteImagesForFamilyInternalServerError) IsClientError() bool {
-	return false
-}
-
-// IsServerError returns true when this delete images for family internal server error response has a 5xx status code
-func (o *DeleteImagesForFamilyInternalServerError) IsServerError() bool {
-	return true
-}
-
-// IsCode returns true when this delete images for family internal server error response a status code equal to that given
-func (o *DeleteImagesForFamilyInternalServerError) IsCode(code int) bool {
-	return code == 500
-}
-
-// Code gets the status code for the delete images for family internal server error response
-func (o *DeleteImagesForFamilyInternalServerError) Code() int {
-	return 500
-}
-
 func (o *DeleteImagesForFamilyInternalServerError) Error() string {
 	return fmt.Sprintf("[DELETE /workload/v1/stacks/{stack_id}/images/{image_family}][%d] deleteImagesForFamilyInternalServerError  %+v", 500, o.Payload)
 }
-
-func (o *DeleteImagesForFamilyInternalServerError) String() string {
-	return fmt.Sprintf("[DELETE /workload/v1/stacks/{stack_id}/images/{image_family}][%d] deleteImagesForFamilyInternalServerError  %+v", 500, o.Payload)
-}
-
 func (o *DeleteImagesForFamilyInternalServerError) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }
@@ -263,31 +159,6 @@ type DeleteImagesForFamilyDefault struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this delete images for family default response has a 2xx status code
-func (o *DeleteImagesForFamilyDefault) IsSuccess() bool {
-	return o._statusCode/100 == 2
-}
-
-// IsRedirect returns true when this delete images for family default response has a 3xx status code
-func (o *DeleteImagesForFamilyDefault) IsRedirect() bool {
-	return o._statusCode/100 == 3
-}
-
-// IsClientError returns true when this delete images for family default response has a 4xx status code
-func (o *DeleteImagesForFamilyDefault) IsClientError() bool {
-	return o._statusCode/100 == 4
-}
-
-// IsServerError returns true when this delete images for family default response has a 5xx status code
-func (o *DeleteImagesForFamilyDefault) IsServerError() bool {
-	return o._statusCode/100 == 5
-}
-
-// IsCode returns true when this delete images for family default response a status code equal to that given
-func (o *DeleteImagesForFamilyDefault) IsCode(code int) bool {
-	return o._statusCode == code
-}
-
 // Code gets the status code for the delete images for family default response
 func (o *DeleteImagesForFamilyDefault) Code() int {
 	return o._statusCode
@@ -296,11 +167,6 @@ func (o *DeleteImagesForFamilyDefault) Code() int {
 func (o *DeleteImagesForFamilyDefault) Error() string {
 	return fmt.Sprintf("[DELETE /workload/v1/stacks/{stack_id}/images/{image_family}][%d] DeleteImagesForFamily default  %+v", o._statusCode, o.Payload)
 }
-
-func (o *DeleteImagesForFamilyDefault) String() string {
-	return fmt.Sprintf("[DELETE /workload/v1/stacks/{stack_id}/images/{image_family}][%d] DeleteImagesForFamily default  %+v", o._statusCode, o.Payload)
-}
-
 func (o *DeleteImagesForFamilyDefault) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }

--- a/stackpath/api/workload/workload_client/virtual_machine_images/get_image_responses.go
+++ b/stackpath/api/workload/workload_client/virtual_machine_images/get_image_responses.go
@@ -67,44 +67,9 @@ type GetImageOK struct {
 	Payload *workload_models.V1GetImageResponse
 }
 
-// IsSuccess returns true when this get image o k response has a 2xx status code
-func (o *GetImageOK) IsSuccess() bool {
-	return true
-}
-
-// IsRedirect returns true when this get image o k response has a 3xx status code
-func (o *GetImageOK) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this get image o k response has a 4xx status code
-func (o *GetImageOK) IsClientError() bool {
-	return false
-}
-
-// IsServerError returns true when this get image o k response has a 5xx status code
-func (o *GetImageOK) IsServerError() bool {
-	return false
-}
-
-// IsCode returns true when this get image o k response a status code equal to that given
-func (o *GetImageOK) IsCode(code int) bool {
-	return code == 200
-}
-
-// Code gets the status code for the get image o k response
-func (o *GetImageOK) Code() int {
-	return 200
-}
-
 func (o *GetImageOK) Error() string {
 	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/images/{image_family}/{image_tag}][%d] getImageOK  %+v", 200, o.Payload)
 }
-
-func (o *GetImageOK) String() string {
-	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/images/{image_family}/{image_tag}][%d] getImageOK  %+v", 200, o.Payload)
-}
-
 func (o *GetImageOK) GetPayload() *workload_models.V1GetImageResponse {
 	return o.Payload
 }
@@ -135,44 +100,9 @@ type GetImageUnauthorized struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this get image unauthorized response has a 2xx status code
-func (o *GetImageUnauthorized) IsSuccess() bool {
-	return false
-}
-
-// IsRedirect returns true when this get image unauthorized response has a 3xx status code
-func (o *GetImageUnauthorized) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this get image unauthorized response has a 4xx status code
-func (o *GetImageUnauthorized) IsClientError() bool {
-	return true
-}
-
-// IsServerError returns true when this get image unauthorized response has a 5xx status code
-func (o *GetImageUnauthorized) IsServerError() bool {
-	return false
-}
-
-// IsCode returns true when this get image unauthorized response a status code equal to that given
-func (o *GetImageUnauthorized) IsCode(code int) bool {
-	return code == 401
-}
-
-// Code gets the status code for the get image unauthorized response
-func (o *GetImageUnauthorized) Code() int {
-	return 401
-}
-
 func (o *GetImageUnauthorized) Error() string {
 	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/images/{image_family}/{image_tag}][%d] getImageUnauthorized  %+v", 401, o.Payload)
 }
-
-func (o *GetImageUnauthorized) String() string {
-	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/images/{image_family}/{image_tag}][%d] getImageUnauthorized  %+v", 401, o.Payload)
-}
-
 func (o *GetImageUnauthorized) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }
@@ -203,44 +133,9 @@ type GetImageInternalServerError struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this get image internal server error response has a 2xx status code
-func (o *GetImageInternalServerError) IsSuccess() bool {
-	return false
-}
-
-// IsRedirect returns true when this get image internal server error response has a 3xx status code
-func (o *GetImageInternalServerError) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this get image internal server error response has a 4xx status code
-func (o *GetImageInternalServerError) IsClientError() bool {
-	return false
-}
-
-// IsServerError returns true when this get image internal server error response has a 5xx status code
-func (o *GetImageInternalServerError) IsServerError() bool {
-	return true
-}
-
-// IsCode returns true when this get image internal server error response a status code equal to that given
-func (o *GetImageInternalServerError) IsCode(code int) bool {
-	return code == 500
-}
-
-// Code gets the status code for the get image internal server error response
-func (o *GetImageInternalServerError) Code() int {
-	return 500
-}
-
 func (o *GetImageInternalServerError) Error() string {
 	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/images/{image_family}/{image_tag}][%d] getImageInternalServerError  %+v", 500, o.Payload)
 }
-
-func (o *GetImageInternalServerError) String() string {
-	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/images/{image_family}/{image_tag}][%d] getImageInternalServerError  %+v", 500, o.Payload)
-}
-
 func (o *GetImageInternalServerError) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }
@@ -275,31 +170,6 @@ type GetImageDefault struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this get image default response has a 2xx status code
-func (o *GetImageDefault) IsSuccess() bool {
-	return o._statusCode/100 == 2
-}
-
-// IsRedirect returns true when this get image default response has a 3xx status code
-func (o *GetImageDefault) IsRedirect() bool {
-	return o._statusCode/100 == 3
-}
-
-// IsClientError returns true when this get image default response has a 4xx status code
-func (o *GetImageDefault) IsClientError() bool {
-	return o._statusCode/100 == 4
-}
-
-// IsServerError returns true when this get image default response has a 5xx status code
-func (o *GetImageDefault) IsServerError() bool {
-	return o._statusCode/100 == 5
-}
-
-// IsCode returns true when this get image default response a status code equal to that given
-func (o *GetImageDefault) IsCode(code int) bool {
-	return o._statusCode == code
-}
-
 // Code gets the status code for the get image default response
 func (o *GetImageDefault) Code() int {
 	return o._statusCode
@@ -308,11 +178,6 @@ func (o *GetImageDefault) Code() int {
 func (o *GetImageDefault) Error() string {
 	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/images/{image_family}/{image_tag}][%d] GetImage default  %+v", o._statusCode, o.Payload)
 }
-
-func (o *GetImageDefault) String() string {
-	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/images/{image_family}/{image_tag}][%d] GetImage default  %+v", o._statusCode, o.Payload)
-}
-
 func (o *GetImageDefault) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }

--- a/stackpath/api/workload/workload_client/virtual_machine_images/get_images_for_family_responses.go
+++ b/stackpath/api/workload/workload_client/virtual_machine_images/get_images_for_family_responses.go
@@ -67,44 +67,9 @@ type GetImagesForFamilyOK struct {
 	Payload *workload_models.V1GetImagesForFamilyResponse
 }
 
-// IsSuccess returns true when this get images for family o k response has a 2xx status code
-func (o *GetImagesForFamilyOK) IsSuccess() bool {
-	return true
-}
-
-// IsRedirect returns true when this get images for family o k response has a 3xx status code
-func (o *GetImagesForFamilyOK) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this get images for family o k response has a 4xx status code
-func (o *GetImagesForFamilyOK) IsClientError() bool {
-	return false
-}
-
-// IsServerError returns true when this get images for family o k response has a 5xx status code
-func (o *GetImagesForFamilyOK) IsServerError() bool {
-	return false
-}
-
-// IsCode returns true when this get images for family o k response a status code equal to that given
-func (o *GetImagesForFamilyOK) IsCode(code int) bool {
-	return code == 200
-}
-
-// Code gets the status code for the get images for family o k response
-func (o *GetImagesForFamilyOK) Code() int {
-	return 200
-}
-
 func (o *GetImagesForFamilyOK) Error() string {
 	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/images/{image_family}][%d] getImagesForFamilyOK  %+v", 200, o.Payload)
 }
-
-func (o *GetImagesForFamilyOK) String() string {
-	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/images/{image_family}][%d] getImagesForFamilyOK  %+v", 200, o.Payload)
-}
-
 func (o *GetImagesForFamilyOK) GetPayload() *workload_models.V1GetImagesForFamilyResponse {
 	return o.Payload
 }
@@ -135,44 +100,9 @@ type GetImagesForFamilyUnauthorized struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this get images for family unauthorized response has a 2xx status code
-func (o *GetImagesForFamilyUnauthorized) IsSuccess() bool {
-	return false
-}
-
-// IsRedirect returns true when this get images for family unauthorized response has a 3xx status code
-func (o *GetImagesForFamilyUnauthorized) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this get images for family unauthorized response has a 4xx status code
-func (o *GetImagesForFamilyUnauthorized) IsClientError() bool {
-	return true
-}
-
-// IsServerError returns true when this get images for family unauthorized response has a 5xx status code
-func (o *GetImagesForFamilyUnauthorized) IsServerError() bool {
-	return false
-}
-
-// IsCode returns true when this get images for family unauthorized response a status code equal to that given
-func (o *GetImagesForFamilyUnauthorized) IsCode(code int) bool {
-	return code == 401
-}
-
-// Code gets the status code for the get images for family unauthorized response
-func (o *GetImagesForFamilyUnauthorized) Code() int {
-	return 401
-}
-
 func (o *GetImagesForFamilyUnauthorized) Error() string {
 	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/images/{image_family}][%d] getImagesForFamilyUnauthorized  %+v", 401, o.Payload)
 }
-
-func (o *GetImagesForFamilyUnauthorized) String() string {
-	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/images/{image_family}][%d] getImagesForFamilyUnauthorized  %+v", 401, o.Payload)
-}
-
 func (o *GetImagesForFamilyUnauthorized) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }
@@ -203,44 +133,9 @@ type GetImagesForFamilyInternalServerError struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this get images for family internal server error response has a 2xx status code
-func (o *GetImagesForFamilyInternalServerError) IsSuccess() bool {
-	return false
-}
-
-// IsRedirect returns true when this get images for family internal server error response has a 3xx status code
-func (o *GetImagesForFamilyInternalServerError) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this get images for family internal server error response has a 4xx status code
-func (o *GetImagesForFamilyInternalServerError) IsClientError() bool {
-	return false
-}
-
-// IsServerError returns true when this get images for family internal server error response has a 5xx status code
-func (o *GetImagesForFamilyInternalServerError) IsServerError() bool {
-	return true
-}
-
-// IsCode returns true when this get images for family internal server error response a status code equal to that given
-func (o *GetImagesForFamilyInternalServerError) IsCode(code int) bool {
-	return code == 500
-}
-
-// Code gets the status code for the get images for family internal server error response
-func (o *GetImagesForFamilyInternalServerError) Code() int {
-	return 500
-}
-
 func (o *GetImagesForFamilyInternalServerError) Error() string {
 	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/images/{image_family}][%d] getImagesForFamilyInternalServerError  %+v", 500, o.Payload)
 }
-
-func (o *GetImagesForFamilyInternalServerError) String() string {
-	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/images/{image_family}][%d] getImagesForFamilyInternalServerError  %+v", 500, o.Payload)
-}
-
 func (o *GetImagesForFamilyInternalServerError) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }
@@ -275,31 +170,6 @@ type GetImagesForFamilyDefault struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this get images for family default response has a 2xx status code
-func (o *GetImagesForFamilyDefault) IsSuccess() bool {
-	return o._statusCode/100 == 2
-}
-
-// IsRedirect returns true when this get images for family default response has a 3xx status code
-func (o *GetImagesForFamilyDefault) IsRedirect() bool {
-	return o._statusCode/100 == 3
-}
-
-// IsClientError returns true when this get images for family default response has a 4xx status code
-func (o *GetImagesForFamilyDefault) IsClientError() bool {
-	return o._statusCode/100 == 4
-}
-
-// IsServerError returns true when this get images for family default response has a 5xx status code
-func (o *GetImagesForFamilyDefault) IsServerError() bool {
-	return o._statusCode/100 == 5
-}
-
-// IsCode returns true when this get images for family default response a status code equal to that given
-func (o *GetImagesForFamilyDefault) IsCode(code int) bool {
-	return o._statusCode == code
-}
-
 // Code gets the status code for the get images for family default response
 func (o *GetImagesForFamilyDefault) Code() int {
 	return o._statusCode
@@ -308,11 +178,6 @@ func (o *GetImagesForFamilyDefault) Code() int {
 func (o *GetImagesForFamilyDefault) Error() string {
 	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/images/{image_family}][%d] GetImagesForFamily default  %+v", o._statusCode, o.Payload)
 }
-
-func (o *GetImagesForFamilyDefault) String() string {
-	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/images/{image_family}][%d] GetImagesForFamily default  %+v", o._statusCode, o.Payload)
-}
-
 func (o *GetImagesForFamilyDefault) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }

--- a/stackpath/api/workload/workload_client/virtual_machine_images/get_images_responses.go
+++ b/stackpath/api/workload/workload_client/virtual_machine_images/get_images_responses.go
@@ -67,44 +67,9 @@ type GetImagesOK struct {
 	Payload *workload_models.V1GetImagesResponse
 }
 
-// IsSuccess returns true when this get images o k response has a 2xx status code
-func (o *GetImagesOK) IsSuccess() bool {
-	return true
-}
-
-// IsRedirect returns true when this get images o k response has a 3xx status code
-func (o *GetImagesOK) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this get images o k response has a 4xx status code
-func (o *GetImagesOK) IsClientError() bool {
-	return false
-}
-
-// IsServerError returns true when this get images o k response has a 5xx status code
-func (o *GetImagesOK) IsServerError() bool {
-	return false
-}
-
-// IsCode returns true when this get images o k response a status code equal to that given
-func (o *GetImagesOK) IsCode(code int) bool {
-	return code == 200
-}
-
-// Code gets the status code for the get images o k response
-func (o *GetImagesOK) Code() int {
-	return 200
-}
-
 func (o *GetImagesOK) Error() string {
 	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/images][%d] getImagesOK  %+v", 200, o.Payload)
 }
-
-func (o *GetImagesOK) String() string {
-	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/images][%d] getImagesOK  %+v", 200, o.Payload)
-}
-
 func (o *GetImagesOK) GetPayload() *workload_models.V1GetImagesResponse {
 	return o.Payload
 }
@@ -135,44 +100,9 @@ type GetImagesUnauthorized struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this get images unauthorized response has a 2xx status code
-func (o *GetImagesUnauthorized) IsSuccess() bool {
-	return false
-}
-
-// IsRedirect returns true when this get images unauthorized response has a 3xx status code
-func (o *GetImagesUnauthorized) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this get images unauthorized response has a 4xx status code
-func (o *GetImagesUnauthorized) IsClientError() bool {
-	return true
-}
-
-// IsServerError returns true when this get images unauthorized response has a 5xx status code
-func (o *GetImagesUnauthorized) IsServerError() bool {
-	return false
-}
-
-// IsCode returns true when this get images unauthorized response a status code equal to that given
-func (o *GetImagesUnauthorized) IsCode(code int) bool {
-	return code == 401
-}
-
-// Code gets the status code for the get images unauthorized response
-func (o *GetImagesUnauthorized) Code() int {
-	return 401
-}
-
 func (o *GetImagesUnauthorized) Error() string {
 	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/images][%d] getImagesUnauthorized  %+v", 401, o.Payload)
 }
-
-func (o *GetImagesUnauthorized) String() string {
-	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/images][%d] getImagesUnauthorized  %+v", 401, o.Payload)
-}
-
 func (o *GetImagesUnauthorized) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }
@@ -203,44 +133,9 @@ type GetImagesInternalServerError struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this get images internal server error response has a 2xx status code
-func (o *GetImagesInternalServerError) IsSuccess() bool {
-	return false
-}
-
-// IsRedirect returns true when this get images internal server error response has a 3xx status code
-func (o *GetImagesInternalServerError) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this get images internal server error response has a 4xx status code
-func (o *GetImagesInternalServerError) IsClientError() bool {
-	return false
-}
-
-// IsServerError returns true when this get images internal server error response has a 5xx status code
-func (o *GetImagesInternalServerError) IsServerError() bool {
-	return true
-}
-
-// IsCode returns true when this get images internal server error response a status code equal to that given
-func (o *GetImagesInternalServerError) IsCode(code int) bool {
-	return code == 500
-}
-
-// Code gets the status code for the get images internal server error response
-func (o *GetImagesInternalServerError) Code() int {
-	return 500
-}
-
 func (o *GetImagesInternalServerError) Error() string {
 	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/images][%d] getImagesInternalServerError  %+v", 500, o.Payload)
 }
-
-func (o *GetImagesInternalServerError) String() string {
-	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/images][%d] getImagesInternalServerError  %+v", 500, o.Payload)
-}
-
 func (o *GetImagesInternalServerError) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }
@@ -275,31 +170,6 @@ type GetImagesDefault struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this get images default response has a 2xx status code
-func (o *GetImagesDefault) IsSuccess() bool {
-	return o._statusCode/100 == 2
-}
-
-// IsRedirect returns true when this get images default response has a 3xx status code
-func (o *GetImagesDefault) IsRedirect() bool {
-	return o._statusCode/100 == 3
-}
-
-// IsClientError returns true when this get images default response has a 4xx status code
-func (o *GetImagesDefault) IsClientError() bool {
-	return o._statusCode/100 == 4
-}
-
-// IsServerError returns true when this get images default response has a 5xx status code
-func (o *GetImagesDefault) IsServerError() bool {
-	return o._statusCode/100 == 5
-}
-
-// IsCode returns true when this get images default response a status code equal to that given
-func (o *GetImagesDefault) IsCode(code int) bool {
-	return o._statusCode == code
-}
-
 // Code gets the status code for the get images default response
 func (o *GetImagesDefault) Code() int {
 	return o._statusCode
@@ -308,11 +178,6 @@ func (o *GetImagesDefault) Code() int {
 func (o *GetImagesDefault) Error() string {
 	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/images][%d] GetImages default  %+v", o._statusCode, o.Payload)
 }
-
-func (o *GetImagesDefault) String() string {
-	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/images][%d] GetImages default  %+v", o._statusCode, o.Payload)
-}
-
 func (o *GetImagesDefault) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }

--- a/stackpath/api/workload/workload_client/virtual_machine_images/update_image_deprecation_responses.go
+++ b/stackpath/api/workload/workload_client/virtual_machine_images/update_image_deprecation_responses.go
@@ -67,44 +67,9 @@ type UpdateImageDeprecationOK struct {
 	Payload *workload_models.V1UpdateImageDeprecationResponse
 }
 
-// IsSuccess returns true when this update image deprecation o k response has a 2xx status code
-func (o *UpdateImageDeprecationOK) IsSuccess() bool {
-	return true
-}
-
-// IsRedirect returns true when this update image deprecation o k response has a 3xx status code
-func (o *UpdateImageDeprecationOK) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this update image deprecation o k response has a 4xx status code
-func (o *UpdateImageDeprecationOK) IsClientError() bool {
-	return false
-}
-
-// IsServerError returns true when this update image deprecation o k response has a 5xx status code
-func (o *UpdateImageDeprecationOK) IsServerError() bool {
-	return false
-}
-
-// IsCode returns true when this update image deprecation o k response a status code equal to that given
-func (o *UpdateImageDeprecationOK) IsCode(code int) bool {
-	return code == 200
-}
-
-// Code gets the status code for the update image deprecation o k response
-func (o *UpdateImageDeprecationOK) Code() int {
-	return 200
-}
-
 func (o *UpdateImageDeprecationOK) Error() string {
 	return fmt.Sprintf("[PUT /workload/v1/stacks/{stack_id}/images/{image_family}/{image_tag}/deprecation][%d] updateImageDeprecationOK  %+v", 200, o.Payload)
 }
-
-func (o *UpdateImageDeprecationOK) String() string {
-	return fmt.Sprintf("[PUT /workload/v1/stacks/{stack_id}/images/{image_family}/{image_tag}/deprecation][%d] updateImageDeprecationOK  %+v", 200, o.Payload)
-}
-
 func (o *UpdateImageDeprecationOK) GetPayload() *workload_models.V1UpdateImageDeprecationResponse {
 	return o.Payload
 }
@@ -135,44 +100,9 @@ type UpdateImageDeprecationUnauthorized struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this update image deprecation unauthorized response has a 2xx status code
-func (o *UpdateImageDeprecationUnauthorized) IsSuccess() bool {
-	return false
-}
-
-// IsRedirect returns true when this update image deprecation unauthorized response has a 3xx status code
-func (o *UpdateImageDeprecationUnauthorized) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this update image deprecation unauthorized response has a 4xx status code
-func (o *UpdateImageDeprecationUnauthorized) IsClientError() bool {
-	return true
-}
-
-// IsServerError returns true when this update image deprecation unauthorized response has a 5xx status code
-func (o *UpdateImageDeprecationUnauthorized) IsServerError() bool {
-	return false
-}
-
-// IsCode returns true when this update image deprecation unauthorized response a status code equal to that given
-func (o *UpdateImageDeprecationUnauthorized) IsCode(code int) bool {
-	return code == 401
-}
-
-// Code gets the status code for the update image deprecation unauthorized response
-func (o *UpdateImageDeprecationUnauthorized) Code() int {
-	return 401
-}
-
 func (o *UpdateImageDeprecationUnauthorized) Error() string {
 	return fmt.Sprintf("[PUT /workload/v1/stacks/{stack_id}/images/{image_family}/{image_tag}/deprecation][%d] updateImageDeprecationUnauthorized  %+v", 401, o.Payload)
 }
-
-func (o *UpdateImageDeprecationUnauthorized) String() string {
-	return fmt.Sprintf("[PUT /workload/v1/stacks/{stack_id}/images/{image_family}/{image_tag}/deprecation][%d] updateImageDeprecationUnauthorized  %+v", 401, o.Payload)
-}
-
 func (o *UpdateImageDeprecationUnauthorized) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }
@@ -203,44 +133,9 @@ type UpdateImageDeprecationInternalServerError struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this update image deprecation internal server error response has a 2xx status code
-func (o *UpdateImageDeprecationInternalServerError) IsSuccess() bool {
-	return false
-}
-
-// IsRedirect returns true when this update image deprecation internal server error response has a 3xx status code
-func (o *UpdateImageDeprecationInternalServerError) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this update image deprecation internal server error response has a 4xx status code
-func (o *UpdateImageDeprecationInternalServerError) IsClientError() bool {
-	return false
-}
-
-// IsServerError returns true when this update image deprecation internal server error response has a 5xx status code
-func (o *UpdateImageDeprecationInternalServerError) IsServerError() bool {
-	return true
-}
-
-// IsCode returns true when this update image deprecation internal server error response a status code equal to that given
-func (o *UpdateImageDeprecationInternalServerError) IsCode(code int) bool {
-	return code == 500
-}
-
-// Code gets the status code for the update image deprecation internal server error response
-func (o *UpdateImageDeprecationInternalServerError) Code() int {
-	return 500
-}
-
 func (o *UpdateImageDeprecationInternalServerError) Error() string {
 	return fmt.Sprintf("[PUT /workload/v1/stacks/{stack_id}/images/{image_family}/{image_tag}/deprecation][%d] updateImageDeprecationInternalServerError  %+v", 500, o.Payload)
 }
-
-func (o *UpdateImageDeprecationInternalServerError) String() string {
-	return fmt.Sprintf("[PUT /workload/v1/stacks/{stack_id}/images/{image_family}/{image_tag}/deprecation][%d] updateImageDeprecationInternalServerError  %+v", 500, o.Payload)
-}
-
 func (o *UpdateImageDeprecationInternalServerError) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }
@@ -275,31 +170,6 @@ type UpdateImageDeprecationDefault struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this update image deprecation default response has a 2xx status code
-func (o *UpdateImageDeprecationDefault) IsSuccess() bool {
-	return o._statusCode/100 == 2
-}
-
-// IsRedirect returns true when this update image deprecation default response has a 3xx status code
-func (o *UpdateImageDeprecationDefault) IsRedirect() bool {
-	return o._statusCode/100 == 3
-}
-
-// IsClientError returns true when this update image deprecation default response has a 4xx status code
-func (o *UpdateImageDeprecationDefault) IsClientError() bool {
-	return o._statusCode/100 == 4
-}
-
-// IsServerError returns true when this update image deprecation default response has a 5xx status code
-func (o *UpdateImageDeprecationDefault) IsServerError() bool {
-	return o._statusCode/100 == 5
-}
-
-// IsCode returns true when this update image deprecation default response a status code equal to that given
-func (o *UpdateImageDeprecationDefault) IsCode(code int) bool {
-	return o._statusCode == code
-}
-
 // Code gets the status code for the update image deprecation default response
 func (o *UpdateImageDeprecationDefault) Code() int {
 	return o._statusCode
@@ -308,11 +178,6 @@ func (o *UpdateImageDeprecationDefault) Code() int {
 func (o *UpdateImageDeprecationDefault) Error() string {
 	return fmt.Sprintf("[PUT /workload/v1/stacks/{stack_id}/images/{image_family}/{image_tag}/deprecation][%d] UpdateImageDeprecation default  %+v", o._statusCode, o.Payload)
 }
-
-func (o *UpdateImageDeprecationDefault) String() string {
-	return fmt.Sprintf("[PUT /workload/v1/stacks/{stack_id}/images/{image_family}/{image_tag}/deprecation][%d] UpdateImageDeprecation default  %+v", o._statusCode, o.Payload)
-}
-
 func (o *UpdateImageDeprecationDefault) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }

--- a/stackpath/api/workload/workload_client/virtual_machine_images/update_image_responses.go
+++ b/stackpath/api/workload/workload_client/virtual_machine_images/update_image_responses.go
@@ -67,44 +67,9 @@ type UpdateImageOK struct {
 	Payload *workload_models.V1UpdateImageResponse
 }
 
-// IsSuccess returns true when this update image o k response has a 2xx status code
-func (o *UpdateImageOK) IsSuccess() bool {
-	return true
-}
-
-// IsRedirect returns true when this update image o k response has a 3xx status code
-func (o *UpdateImageOK) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this update image o k response has a 4xx status code
-func (o *UpdateImageOK) IsClientError() bool {
-	return false
-}
-
-// IsServerError returns true when this update image o k response has a 5xx status code
-func (o *UpdateImageOK) IsServerError() bool {
-	return false
-}
-
-// IsCode returns true when this update image o k response a status code equal to that given
-func (o *UpdateImageOK) IsCode(code int) bool {
-	return code == 200
-}
-
-// Code gets the status code for the update image o k response
-func (o *UpdateImageOK) Code() int {
-	return 200
-}
-
 func (o *UpdateImageOK) Error() string {
 	return fmt.Sprintf("[PATCH /workload/v1/stacks/{stack_id}/images/{image_family}/{image_tag}][%d] updateImageOK  %+v", 200, o.Payload)
 }
-
-func (o *UpdateImageOK) String() string {
-	return fmt.Sprintf("[PATCH /workload/v1/stacks/{stack_id}/images/{image_family}/{image_tag}][%d] updateImageOK  %+v", 200, o.Payload)
-}
-
 func (o *UpdateImageOK) GetPayload() *workload_models.V1UpdateImageResponse {
 	return o.Payload
 }
@@ -135,44 +100,9 @@ type UpdateImageUnauthorized struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this update image unauthorized response has a 2xx status code
-func (o *UpdateImageUnauthorized) IsSuccess() bool {
-	return false
-}
-
-// IsRedirect returns true when this update image unauthorized response has a 3xx status code
-func (o *UpdateImageUnauthorized) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this update image unauthorized response has a 4xx status code
-func (o *UpdateImageUnauthorized) IsClientError() bool {
-	return true
-}
-
-// IsServerError returns true when this update image unauthorized response has a 5xx status code
-func (o *UpdateImageUnauthorized) IsServerError() bool {
-	return false
-}
-
-// IsCode returns true when this update image unauthorized response a status code equal to that given
-func (o *UpdateImageUnauthorized) IsCode(code int) bool {
-	return code == 401
-}
-
-// Code gets the status code for the update image unauthorized response
-func (o *UpdateImageUnauthorized) Code() int {
-	return 401
-}
-
 func (o *UpdateImageUnauthorized) Error() string {
 	return fmt.Sprintf("[PATCH /workload/v1/stacks/{stack_id}/images/{image_family}/{image_tag}][%d] updateImageUnauthorized  %+v", 401, o.Payload)
 }
-
-func (o *UpdateImageUnauthorized) String() string {
-	return fmt.Sprintf("[PATCH /workload/v1/stacks/{stack_id}/images/{image_family}/{image_tag}][%d] updateImageUnauthorized  %+v", 401, o.Payload)
-}
-
 func (o *UpdateImageUnauthorized) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }
@@ -203,44 +133,9 @@ type UpdateImageInternalServerError struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this update image internal server error response has a 2xx status code
-func (o *UpdateImageInternalServerError) IsSuccess() bool {
-	return false
-}
-
-// IsRedirect returns true when this update image internal server error response has a 3xx status code
-func (o *UpdateImageInternalServerError) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this update image internal server error response has a 4xx status code
-func (o *UpdateImageInternalServerError) IsClientError() bool {
-	return false
-}
-
-// IsServerError returns true when this update image internal server error response has a 5xx status code
-func (o *UpdateImageInternalServerError) IsServerError() bool {
-	return true
-}
-
-// IsCode returns true when this update image internal server error response a status code equal to that given
-func (o *UpdateImageInternalServerError) IsCode(code int) bool {
-	return code == 500
-}
-
-// Code gets the status code for the update image internal server error response
-func (o *UpdateImageInternalServerError) Code() int {
-	return 500
-}
-
 func (o *UpdateImageInternalServerError) Error() string {
 	return fmt.Sprintf("[PATCH /workload/v1/stacks/{stack_id}/images/{image_family}/{image_tag}][%d] updateImageInternalServerError  %+v", 500, o.Payload)
 }
-
-func (o *UpdateImageInternalServerError) String() string {
-	return fmt.Sprintf("[PATCH /workload/v1/stacks/{stack_id}/images/{image_family}/{image_tag}][%d] updateImageInternalServerError  %+v", 500, o.Payload)
-}
-
 func (o *UpdateImageInternalServerError) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }
@@ -275,31 +170,6 @@ type UpdateImageDefault struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this update image default response has a 2xx status code
-func (o *UpdateImageDefault) IsSuccess() bool {
-	return o._statusCode/100 == 2
-}
-
-// IsRedirect returns true when this update image default response has a 3xx status code
-func (o *UpdateImageDefault) IsRedirect() bool {
-	return o._statusCode/100 == 3
-}
-
-// IsClientError returns true when this update image default response has a 4xx status code
-func (o *UpdateImageDefault) IsClientError() bool {
-	return o._statusCode/100 == 4
-}
-
-// IsServerError returns true when this update image default response has a 5xx status code
-func (o *UpdateImageDefault) IsServerError() bool {
-	return o._statusCode/100 == 5
-}
-
-// IsCode returns true when this update image default response a status code equal to that given
-func (o *UpdateImageDefault) IsCode(code int) bool {
-	return o._statusCode == code
-}
-
 // Code gets the status code for the update image default response
 func (o *UpdateImageDefault) Code() int {
 	return o._statusCode
@@ -308,11 +178,6 @@ func (o *UpdateImageDefault) Code() int {
 func (o *UpdateImageDefault) Error() string {
 	return fmt.Sprintf("[PATCH /workload/v1/stacks/{stack_id}/images/{image_family}/{image_tag}][%d] UpdateImage default  %+v", o._statusCode, o.Payload)
 }
-
-func (o *UpdateImageDefault) String() string {
-	return fmt.Sprintf("[PATCH /workload/v1/stacks/{stack_id}/images/{image_family}/{image_tag}][%d] UpdateImage default  %+v", o._statusCode, o.Payload)
-}
-
 func (o *UpdateImageDefault) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }

--- a/stackpath/api/workload/workload_client/workloads/create_workload_responses.go
+++ b/stackpath/api/workload/workload_client/workloads/create_workload_responses.go
@@ -67,44 +67,9 @@ type CreateWorkloadOK struct {
 	Payload *workload_models.V1CreateWorkloadResponse
 }
 
-// IsSuccess returns true when this create workload o k response has a 2xx status code
-func (o *CreateWorkloadOK) IsSuccess() bool {
-	return true
-}
-
-// IsRedirect returns true when this create workload o k response has a 3xx status code
-func (o *CreateWorkloadOK) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this create workload o k response has a 4xx status code
-func (o *CreateWorkloadOK) IsClientError() bool {
-	return false
-}
-
-// IsServerError returns true when this create workload o k response has a 5xx status code
-func (o *CreateWorkloadOK) IsServerError() bool {
-	return false
-}
-
-// IsCode returns true when this create workload o k response a status code equal to that given
-func (o *CreateWorkloadOK) IsCode(code int) bool {
-	return code == 200
-}
-
-// Code gets the status code for the create workload o k response
-func (o *CreateWorkloadOK) Code() int {
-	return 200
-}
-
 func (o *CreateWorkloadOK) Error() string {
 	return fmt.Sprintf("[POST /workload/v1/stacks/{stack_id}/workloads][%d] createWorkloadOK  %+v", 200, o.Payload)
 }
-
-func (o *CreateWorkloadOK) String() string {
-	return fmt.Sprintf("[POST /workload/v1/stacks/{stack_id}/workloads][%d] createWorkloadOK  %+v", 200, o.Payload)
-}
-
 func (o *CreateWorkloadOK) GetPayload() *workload_models.V1CreateWorkloadResponse {
 	return o.Payload
 }
@@ -135,44 +100,9 @@ type CreateWorkloadUnauthorized struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this create workload unauthorized response has a 2xx status code
-func (o *CreateWorkloadUnauthorized) IsSuccess() bool {
-	return false
-}
-
-// IsRedirect returns true when this create workload unauthorized response has a 3xx status code
-func (o *CreateWorkloadUnauthorized) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this create workload unauthorized response has a 4xx status code
-func (o *CreateWorkloadUnauthorized) IsClientError() bool {
-	return true
-}
-
-// IsServerError returns true when this create workload unauthorized response has a 5xx status code
-func (o *CreateWorkloadUnauthorized) IsServerError() bool {
-	return false
-}
-
-// IsCode returns true when this create workload unauthorized response a status code equal to that given
-func (o *CreateWorkloadUnauthorized) IsCode(code int) bool {
-	return code == 401
-}
-
-// Code gets the status code for the create workload unauthorized response
-func (o *CreateWorkloadUnauthorized) Code() int {
-	return 401
-}
-
 func (o *CreateWorkloadUnauthorized) Error() string {
 	return fmt.Sprintf("[POST /workload/v1/stacks/{stack_id}/workloads][%d] createWorkloadUnauthorized  %+v", 401, o.Payload)
 }
-
-func (o *CreateWorkloadUnauthorized) String() string {
-	return fmt.Sprintf("[POST /workload/v1/stacks/{stack_id}/workloads][%d] createWorkloadUnauthorized  %+v", 401, o.Payload)
-}
-
 func (o *CreateWorkloadUnauthorized) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }
@@ -203,44 +133,9 @@ type CreateWorkloadInternalServerError struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this create workload internal server error response has a 2xx status code
-func (o *CreateWorkloadInternalServerError) IsSuccess() bool {
-	return false
-}
-
-// IsRedirect returns true when this create workload internal server error response has a 3xx status code
-func (o *CreateWorkloadInternalServerError) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this create workload internal server error response has a 4xx status code
-func (o *CreateWorkloadInternalServerError) IsClientError() bool {
-	return false
-}
-
-// IsServerError returns true when this create workload internal server error response has a 5xx status code
-func (o *CreateWorkloadInternalServerError) IsServerError() bool {
-	return true
-}
-
-// IsCode returns true when this create workload internal server error response a status code equal to that given
-func (o *CreateWorkloadInternalServerError) IsCode(code int) bool {
-	return code == 500
-}
-
-// Code gets the status code for the create workload internal server error response
-func (o *CreateWorkloadInternalServerError) Code() int {
-	return 500
-}
-
 func (o *CreateWorkloadInternalServerError) Error() string {
 	return fmt.Sprintf("[POST /workload/v1/stacks/{stack_id}/workloads][%d] createWorkloadInternalServerError  %+v", 500, o.Payload)
 }
-
-func (o *CreateWorkloadInternalServerError) String() string {
-	return fmt.Sprintf("[POST /workload/v1/stacks/{stack_id}/workloads][%d] createWorkloadInternalServerError  %+v", 500, o.Payload)
-}
-
 func (o *CreateWorkloadInternalServerError) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }
@@ -275,31 +170,6 @@ type CreateWorkloadDefault struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this create workload default response has a 2xx status code
-func (o *CreateWorkloadDefault) IsSuccess() bool {
-	return o._statusCode/100 == 2
-}
-
-// IsRedirect returns true when this create workload default response has a 3xx status code
-func (o *CreateWorkloadDefault) IsRedirect() bool {
-	return o._statusCode/100 == 3
-}
-
-// IsClientError returns true when this create workload default response has a 4xx status code
-func (o *CreateWorkloadDefault) IsClientError() bool {
-	return o._statusCode/100 == 4
-}
-
-// IsServerError returns true when this create workload default response has a 5xx status code
-func (o *CreateWorkloadDefault) IsServerError() bool {
-	return o._statusCode/100 == 5
-}
-
-// IsCode returns true when this create workload default response a status code equal to that given
-func (o *CreateWorkloadDefault) IsCode(code int) bool {
-	return o._statusCode == code
-}
-
 // Code gets the status code for the create workload default response
 func (o *CreateWorkloadDefault) Code() int {
 	return o._statusCode
@@ -308,11 +178,6 @@ func (o *CreateWorkloadDefault) Code() int {
 func (o *CreateWorkloadDefault) Error() string {
 	return fmt.Sprintf("[POST /workload/v1/stacks/{stack_id}/workloads][%d] CreateWorkload default  %+v", o._statusCode, o.Payload)
 }
-
-func (o *CreateWorkloadDefault) String() string {
-	return fmt.Sprintf("[POST /workload/v1/stacks/{stack_id}/workloads][%d] CreateWorkload default  %+v", o._statusCode, o.Payload)
-}
-
 func (o *CreateWorkloadDefault) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }

--- a/stackpath/api/workload/workload_client/workloads/delete_workload_responses.go
+++ b/stackpath/api/workload/workload_client/workloads/delete_workload_responses.go
@@ -66,41 +66,7 @@ No content
 type DeleteWorkloadNoContent struct {
 }
 
-// IsSuccess returns true when this delete workload no content response has a 2xx status code
-func (o *DeleteWorkloadNoContent) IsSuccess() bool {
-	return true
-}
-
-// IsRedirect returns true when this delete workload no content response has a 3xx status code
-func (o *DeleteWorkloadNoContent) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this delete workload no content response has a 4xx status code
-func (o *DeleteWorkloadNoContent) IsClientError() bool {
-	return false
-}
-
-// IsServerError returns true when this delete workload no content response has a 5xx status code
-func (o *DeleteWorkloadNoContent) IsServerError() bool {
-	return false
-}
-
-// IsCode returns true when this delete workload no content response a status code equal to that given
-func (o *DeleteWorkloadNoContent) IsCode(code int) bool {
-	return code == 204
-}
-
-// Code gets the status code for the delete workload no content response
-func (o *DeleteWorkloadNoContent) Code() int {
-	return 204
-}
-
 func (o *DeleteWorkloadNoContent) Error() string {
-	return fmt.Sprintf("[DELETE /workload/v1/stacks/{stack_id}/workloads/{workload_id}][%d] deleteWorkloadNoContent ", 204)
-}
-
-func (o *DeleteWorkloadNoContent) String() string {
 	return fmt.Sprintf("[DELETE /workload/v1/stacks/{stack_id}/workloads/{workload_id}][%d] deleteWorkloadNoContent ", 204)
 }
 
@@ -123,44 +89,9 @@ type DeleteWorkloadUnauthorized struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this delete workload unauthorized response has a 2xx status code
-func (o *DeleteWorkloadUnauthorized) IsSuccess() bool {
-	return false
-}
-
-// IsRedirect returns true when this delete workload unauthorized response has a 3xx status code
-func (o *DeleteWorkloadUnauthorized) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this delete workload unauthorized response has a 4xx status code
-func (o *DeleteWorkloadUnauthorized) IsClientError() bool {
-	return true
-}
-
-// IsServerError returns true when this delete workload unauthorized response has a 5xx status code
-func (o *DeleteWorkloadUnauthorized) IsServerError() bool {
-	return false
-}
-
-// IsCode returns true when this delete workload unauthorized response a status code equal to that given
-func (o *DeleteWorkloadUnauthorized) IsCode(code int) bool {
-	return code == 401
-}
-
-// Code gets the status code for the delete workload unauthorized response
-func (o *DeleteWorkloadUnauthorized) Code() int {
-	return 401
-}
-
 func (o *DeleteWorkloadUnauthorized) Error() string {
 	return fmt.Sprintf("[DELETE /workload/v1/stacks/{stack_id}/workloads/{workload_id}][%d] deleteWorkloadUnauthorized  %+v", 401, o.Payload)
 }
-
-func (o *DeleteWorkloadUnauthorized) String() string {
-	return fmt.Sprintf("[DELETE /workload/v1/stacks/{stack_id}/workloads/{workload_id}][%d] deleteWorkloadUnauthorized  %+v", 401, o.Payload)
-}
-
 func (o *DeleteWorkloadUnauthorized) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }
@@ -191,44 +122,9 @@ type DeleteWorkloadInternalServerError struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this delete workload internal server error response has a 2xx status code
-func (o *DeleteWorkloadInternalServerError) IsSuccess() bool {
-	return false
-}
-
-// IsRedirect returns true when this delete workload internal server error response has a 3xx status code
-func (o *DeleteWorkloadInternalServerError) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this delete workload internal server error response has a 4xx status code
-func (o *DeleteWorkloadInternalServerError) IsClientError() bool {
-	return false
-}
-
-// IsServerError returns true when this delete workload internal server error response has a 5xx status code
-func (o *DeleteWorkloadInternalServerError) IsServerError() bool {
-	return true
-}
-
-// IsCode returns true when this delete workload internal server error response a status code equal to that given
-func (o *DeleteWorkloadInternalServerError) IsCode(code int) bool {
-	return code == 500
-}
-
-// Code gets the status code for the delete workload internal server error response
-func (o *DeleteWorkloadInternalServerError) Code() int {
-	return 500
-}
-
 func (o *DeleteWorkloadInternalServerError) Error() string {
 	return fmt.Sprintf("[DELETE /workload/v1/stacks/{stack_id}/workloads/{workload_id}][%d] deleteWorkloadInternalServerError  %+v", 500, o.Payload)
 }
-
-func (o *DeleteWorkloadInternalServerError) String() string {
-	return fmt.Sprintf("[DELETE /workload/v1/stacks/{stack_id}/workloads/{workload_id}][%d] deleteWorkloadInternalServerError  %+v", 500, o.Payload)
-}
-
 func (o *DeleteWorkloadInternalServerError) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }
@@ -263,31 +159,6 @@ type DeleteWorkloadDefault struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this delete workload default response has a 2xx status code
-func (o *DeleteWorkloadDefault) IsSuccess() bool {
-	return o._statusCode/100 == 2
-}
-
-// IsRedirect returns true when this delete workload default response has a 3xx status code
-func (o *DeleteWorkloadDefault) IsRedirect() bool {
-	return o._statusCode/100 == 3
-}
-
-// IsClientError returns true when this delete workload default response has a 4xx status code
-func (o *DeleteWorkloadDefault) IsClientError() bool {
-	return o._statusCode/100 == 4
-}
-
-// IsServerError returns true when this delete workload default response has a 5xx status code
-func (o *DeleteWorkloadDefault) IsServerError() bool {
-	return o._statusCode/100 == 5
-}
-
-// IsCode returns true when this delete workload default response a status code equal to that given
-func (o *DeleteWorkloadDefault) IsCode(code int) bool {
-	return o._statusCode == code
-}
-
 // Code gets the status code for the delete workload default response
 func (o *DeleteWorkloadDefault) Code() int {
 	return o._statusCode
@@ -296,11 +167,6 @@ func (o *DeleteWorkloadDefault) Code() int {
 func (o *DeleteWorkloadDefault) Error() string {
 	return fmt.Sprintf("[DELETE /workload/v1/stacks/{stack_id}/workloads/{workload_id}][%d] DeleteWorkload default  %+v", o._statusCode, o.Payload)
 }
-
-func (o *DeleteWorkloadDefault) String() string {
-	return fmt.Sprintf("[DELETE /workload/v1/stacks/{stack_id}/workloads/{workload_id}][%d] DeleteWorkload default  %+v", o._statusCode, o.Payload)
-}
-
 func (o *DeleteWorkloadDefault) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }

--- a/stackpath/api/workload/workload_client/workloads/get_workload_responses.go
+++ b/stackpath/api/workload/workload_client/workloads/get_workload_responses.go
@@ -67,44 +67,9 @@ type GetWorkloadOK struct {
 	Payload *workload_models.V1GetWorkloadResponse
 }
 
-// IsSuccess returns true when this get workload o k response has a 2xx status code
-func (o *GetWorkloadOK) IsSuccess() bool {
-	return true
-}
-
-// IsRedirect returns true when this get workload o k response has a 3xx status code
-func (o *GetWorkloadOK) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this get workload o k response has a 4xx status code
-func (o *GetWorkloadOK) IsClientError() bool {
-	return false
-}
-
-// IsServerError returns true when this get workload o k response has a 5xx status code
-func (o *GetWorkloadOK) IsServerError() bool {
-	return false
-}
-
-// IsCode returns true when this get workload o k response a status code equal to that given
-func (o *GetWorkloadOK) IsCode(code int) bool {
-	return code == 200
-}
-
-// Code gets the status code for the get workload o k response
-func (o *GetWorkloadOK) Code() int {
-	return 200
-}
-
 func (o *GetWorkloadOK) Error() string {
 	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/workloads/{workload_id}][%d] getWorkloadOK  %+v", 200, o.Payload)
 }
-
-func (o *GetWorkloadOK) String() string {
-	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/workloads/{workload_id}][%d] getWorkloadOK  %+v", 200, o.Payload)
-}
-
 func (o *GetWorkloadOK) GetPayload() *workload_models.V1GetWorkloadResponse {
 	return o.Payload
 }
@@ -135,44 +100,9 @@ type GetWorkloadUnauthorized struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this get workload unauthorized response has a 2xx status code
-func (o *GetWorkloadUnauthorized) IsSuccess() bool {
-	return false
-}
-
-// IsRedirect returns true when this get workload unauthorized response has a 3xx status code
-func (o *GetWorkloadUnauthorized) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this get workload unauthorized response has a 4xx status code
-func (o *GetWorkloadUnauthorized) IsClientError() bool {
-	return true
-}
-
-// IsServerError returns true when this get workload unauthorized response has a 5xx status code
-func (o *GetWorkloadUnauthorized) IsServerError() bool {
-	return false
-}
-
-// IsCode returns true when this get workload unauthorized response a status code equal to that given
-func (o *GetWorkloadUnauthorized) IsCode(code int) bool {
-	return code == 401
-}
-
-// Code gets the status code for the get workload unauthorized response
-func (o *GetWorkloadUnauthorized) Code() int {
-	return 401
-}
-
 func (o *GetWorkloadUnauthorized) Error() string {
 	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/workloads/{workload_id}][%d] getWorkloadUnauthorized  %+v", 401, o.Payload)
 }
-
-func (o *GetWorkloadUnauthorized) String() string {
-	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/workloads/{workload_id}][%d] getWorkloadUnauthorized  %+v", 401, o.Payload)
-}
-
 func (o *GetWorkloadUnauthorized) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }
@@ -203,44 +133,9 @@ type GetWorkloadInternalServerError struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this get workload internal server error response has a 2xx status code
-func (o *GetWorkloadInternalServerError) IsSuccess() bool {
-	return false
-}
-
-// IsRedirect returns true when this get workload internal server error response has a 3xx status code
-func (o *GetWorkloadInternalServerError) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this get workload internal server error response has a 4xx status code
-func (o *GetWorkloadInternalServerError) IsClientError() bool {
-	return false
-}
-
-// IsServerError returns true when this get workload internal server error response has a 5xx status code
-func (o *GetWorkloadInternalServerError) IsServerError() bool {
-	return true
-}
-
-// IsCode returns true when this get workload internal server error response a status code equal to that given
-func (o *GetWorkloadInternalServerError) IsCode(code int) bool {
-	return code == 500
-}
-
-// Code gets the status code for the get workload internal server error response
-func (o *GetWorkloadInternalServerError) Code() int {
-	return 500
-}
-
 func (o *GetWorkloadInternalServerError) Error() string {
 	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/workloads/{workload_id}][%d] getWorkloadInternalServerError  %+v", 500, o.Payload)
 }
-
-func (o *GetWorkloadInternalServerError) String() string {
-	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/workloads/{workload_id}][%d] getWorkloadInternalServerError  %+v", 500, o.Payload)
-}
-
 func (o *GetWorkloadInternalServerError) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }
@@ -275,31 +170,6 @@ type GetWorkloadDefault struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this get workload default response has a 2xx status code
-func (o *GetWorkloadDefault) IsSuccess() bool {
-	return o._statusCode/100 == 2
-}
-
-// IsRedirect returns true when this get workload default response has a 3xx status code
-func (o *GetWorkloadDefault) IsRedirect() bool {
-	return o._statusCode/100 == 3
-}
-
-// IsClientError returns true when this get workload default response has a 4xx status code
-func (o *GetWorkloadDefault) IsClientError() bool {
-	return o._statusCode/100 == 4
-}
-
-// IsServerError returns true when this get workload default response has a 5xx status code
-func (o *GetWorkloadDefault) IsServerError() bool {
-	return o._statusCode/100 == 5
-}
-
-// IsCode returns true when this get workload default response a status code equal to that given
-func (o *GetWorkloadDefault) IsCode(code int) bool {
-	return o._statusCode == code
-}
-
 // Code gets the status code for the get workload default response
 func (o *GetWorkloadDefault) Code() int {
 	return o._statusCode
@@ -308,11 +178,6 @@ func (o *GetWorkloadDefault) Code() int {
 func (o *GetWorkloadDefault) Error() string {
 	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/workloads/{workload_id}][%d] GetWorkload default  %+v", o._statusCode, o.Payload)
 }
-
-func (o *GetWorkloadDefault) String() string {
-	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/workloads/{workload_id}][%d] GetWorkload default  %+v", o._statusCode, o.Payload)
-}
-
 func (o *GetWorkloadDefault) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }

--- a/stackpath/api/workload/workload_client/workloads/get_workloads_responses.go
+++ b/stackpath/api/workload/workload_client/workloads/get_workloads_responses.go
@@ -67,44 +67,9 @@ type GetWorkloadsOK struct {
 	Payload *workload_models.V1GetWorkloadsResponse
 }
 
-// IsSuccess returns true when this get workloads o k response has a 2xx status code
-func (o *GetWorkloadsOK) IsSuccess() bool {
-	return true
-}
-
-// IsRedirect returns true when this get workloads o k response has a 3xx status code
-func (o *GetWorkloadsOK) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this get workloads o k response has a 4xx status code
-func (o *GetWorkloadsOK) IsClientError() bool {
-	return false
-}
-
-// IsServerError returns true when this get workloads o k response has a 5xx status code
-func (o *GetWorkloadsOK) IsServerError() bool {
-	return false
-}
-
-// IsCode returns true when this get workloads o k response a status code equal to that given
-func (o *GetWorkloadsOK) IsCode(code int) bool {
-	return code == 200
-}
-
-// Code gets the status code for the get workloads o k response
-func (o *GetWorkloadsOK) Code() int {
-	return 200
-}
-
 func (o *GetWorkloadsOK) Error() string {
 	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/workloads][%d] getWorkloadsOK  %+v", 200, o.Payload)
 }
-
-func (o *GetWorkloadsOK) String() string {
-	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/workloads][%d] getWorkloadsOK  %+v", 200, o.Payload)
-}
-
 func (o *GetWorkloadsOK) GetPayload() *workload_models.V1GetWorkloadsResponse {
 	return o.Payload
 }
@@ -135,44 +100,9 @@ type GetWorkloadsUnauthorized struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this get workloads unauthorized response has a 2xx status code
-func (o *GetWorkloadsUnauthorized) IsSuccess() bool {
-	return false
-}
-
-// IsRedirect returns true when this get workloads unauthorized response has a 3xx status code
-func (o *GetWorkloadsUnauthorized) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this get workloads unauthorized response has a 4xx status code
-func (o *GetWorkloadsUnauthorized) IsClientError() bool {
-	return true
-}
-
-// IsServerError returns true when this get workloads unauthorized response has a 5xx status code
-func (o *GetWorkloadsUnauthorized) IsServerError() bool {
-	return false
-}
-
-// IsCode returns true when this get workloads unauthorized response a status code equal to that given
-func (o *GetWorkloadsUnauthorized) IsCode(code int) bool {
-	return code == 401
-}
-
-// Code gets the status code for the get workloads unauthorized response
-func (o *GetWorkloadsUnauthorized) Code() int {
-	return 401
-}
-
 func (o *GetWorkloadsUnauthorized) Error() string {
 	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/workloads][%d] getWorkloadsUnauthorized  %+v", 401, o.Payload)
 }
-
-func (o *GetWorkloadsUnauthorized) String() string {
-	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/workloads][%d] getWorkloadsUnauthorized  %+v", 401, o.Payload)
-}
-
 func (o *GetWorkloadsUnauthorized) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }
@@ -203,44 +133,9 @@ type GetWorkloadsInternalServerError struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this get workloads internal server error response has a 2xx status code
-func (o *GetWorkloadsInternalServerError) IsSuccess() bool {
-	return false
-}
-
-// IsRedirect returns true when this get workloads internal server error response has a 3xx status code
-func (o *GetWorkloadsInternalServerError) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this get workloads internal server error response has a 4xx status code
-func (o *GetWorkloadsInternalServerError) IsClientError() bool {
-	return false
-}
-
-// IsServerError returns true when this get workloads internal server error response has a 5xx status code
-func (o *GetWorkloadsInternalServerError) IsServerError() bool {
-	return true
-}
-
-// IsCode returns true when this get workloads internal server error response a status code equal to that given
-func (o *GetWorkloadsInternalServerError) IsCode(code int) bool {
-	return code == 500
-}
-
-// Code gets the status code for the get workloads internal server error response
-func (o *GetWorkloadsInternalServerError) Code() int {
-	return 500
-}
-
 func (o *GetWorkloadsInternalServerError) Error() string {
 	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/workloads][%d] getWorkloadsInternalServerError  %+v", 500, o.Payload)
 }
-
-func (o *GetWorkloadsInternalServerError) String() string {
-	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/workloads][%d] getWorkloadsInternalServerError  %+v", 500, o.Payload)
-}
-
 func (o *GetWorkloadsInternalServerError) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }
@@ -275,31 +170,6 @@ type GetWorkloadsDefault struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this get workloads default response has a 2xx status code
-func (o *GetWorkloadsDefault) IsSuccess() bool {
-	return o._statusCode/100 == 2
-}
-
-// IsRedirect returns true when this get workloads default response has a 3xx status code
-func (o *GetWorkloadsDefault) IsRedirect() bool {
-	return o._statusCode/100 == 3
-}
-
-// IsClientError returns true when this get workloads default response has a 4xx status code
-func (o *GetWorkloadsDefault) IsClientError() bool {
-	return o._statusCode/100 == 4
-}
-
-// IsServerError returns true when this get workloads default response has a 5xx status code
-func (o *GetWorkloadsDefault) IsServerError() bool {
-	return o._statusCode/100 == 5
-}
-
-// IsCode returns true when this get workloads default response a status code equal to that given
-func (o *GetWorkloadsDefault) IsCode(code int) bool {
-	return o._statusCode == code
-}
-
 // Code gets the status code for the get workloads default response
 func (o *GetWorkloadsDefault) Code() int {
 	return o._statusCode
@@ -308,11 +178,6 @@ func (o *GetWorkloadsDefault) Code() int {
 func (o *GetWorkloadsDefault) Error() string {
 	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/workloads][%d] GetWorkloads default  %+v", o._statusCode, o.Payload)
 }
-
-func (o *GetWorkloadsDefault) String() string {
-	return fmt.Sprintf("[GET /workload/v1/stacks/{stack_id}/workloads][%d] GetWorkloads default  %+v", o._statusCode, o.Payload)
-}
-
 func (o *GetWorkloadsDefault) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }

--- a/stackpath/api/workload/workload_client/workloads/put_workload_responses.go
+++ b/stackpath/api/workload/workload_client/workloads/put_workload_responses.go
@@ -67,44 +67,9 @@ type PutWorkloadOK struct {
 	Payload *workload_models.V1PutWorkloadResponse
 }
 
-// IsSuccess returns true when this put workload o k response has a 2xx status code
-func (o *PutWorkloadOK) IsSuccess() bool {
-	return true
-}
-
-// IsRedirect returns true when this put workload o k response has a 3xx status code
-func (o *PutWorkloadOK) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this put workload o k response has a 4xx status code
-func (o *PutWorkloadOK) IsClientError() bool {
-	return false
-}
-
-// IsServerError returns true when this put workload o k response has a 5xx status code
-func (o *PutWorkloadOK) IsServerError() bool {
-	return false
-}
-
-// IsCode returns true when this put workload o k response a status code equal to that given
-func (o *PutWorkloadOK) IsCode(code int) bool {
-	return code == 200
-}
-
-// Code gets the status code for the put workload o k response
-func (o *PutWorkloadOK) Code() int {
-	return 200
-}
-
 func (o *PutWorkloadOK) Error() string {
 	return fmt.Sprintf("[PUT /workload/v1/stacks/{stack_id}/workloads/{workload_id}][%d] putWorkloadOK  %+v", 200, o.Payload)
 }
-
-func (o *PutWorkloadOK) String() string {
-	return fmt.Sprintf("[PUT /workload/v1/stacks/{stack_id}/workloads/{workload_id}][%d] putWorkloadOK  %+v", 200, o.Payload)
-}
-
 func (o *PutWorkloadOK) GetPayload() *workload_models.V1PutWorkloadResponse {
 	return o.Payload
 }
@@ -135,44 +100,9 @@ type PutWorkloadUnauthorized struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this put workload unauthorized response has a 2xx status code
-func (o *PutWorkloadUnauthorized) IsSuccess() bool {
-	return false
-}
-
-// IsRedirect returns true when this put workload unauthorized response has a 3xx status code
-func (o *PutWorkloadUnauthorized) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this put workload unauthorized response has a 4xx status code
-func (o *PutWorkloadUnauthorized) IsClientError() bool {
-	return true
-}
-
-// IsServerError returns true when this put workload unauthorized response has a 5xx status code
-func (o *PutWorkloadUnauthorized) IsServerError() bool {
-	return false
-}
-
-// IsCode returns true when this put workload unauthorized response a status code equal to that given
-func (o *PutWorkloadUnauthorized) IsCode(code int) bool {
-	return code == 401
-}
-
-// Code gets the status code for the put workload unauthorized response
-func (o *PutWorkloadUnauthorized) Code() int {
-	return 401
-}
-
 func (o *PutWorkloadUnauthorized) Error() string {
 	return fmt.Sprintf("[PUT /workload/v1/stacks/{stack_id}/workloads/{workload_id}][%d] putWorkloadUnauthorized  %+v", 401, o.Payload)
 }
-
-func (o *PutWorkloadUnauthorized) String() string {
-	return fmt.Sprintf("[PUT /workload/v1/stacks/{stack_id}/workloads/{workload_id}][%d] putWorkloadUnauthorized  %+v", 401, o.Payload)
-}
-
 func (o *PutWorkloadUnauthorized) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }
@@ -203,44 +133,9 @@ type PutWorkloadInternalServerError struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this put workload internal server error response has a 2xx status code
-func (o *PutWorkloadInternalServerError) IsSuccess() bool {
-	return false
-}
-
-// IsRedirect returns true when this put workload internal server error response has a 3xx status code
-func (o *PutWorkloadInternalServerError) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this put workload internal server error response has a 4xx status code
-func (o *PutWorkloadInternalServerError) IsClientError() bool {
-	return false
-}
-
-// IsServerError returns true when this put workload internal server error response has a 5xx status code
-func (o *PutWorkloadInternalServerError) IsServerError() bool {
-	return true
-}
-
-// IsCode returns true when this put workload internal server error response a status code equal to that given
-func (o *PutWorkloadInternalServerError) IsCode(code int) bool {
-	return code == 500
-}
-
-// Code gets the status code for the put workload internal server error response
-func (o *PutWorkloadInternalServerError) Code() int {
-	return 500
-}
-
 func (o *PutWorkloadInternalServerError) Error() string {
 	return fmt.Sprintf("[PUT /workload/v1/stacks/{stack_id}/workloads/{workload_id}][%d] putWorkloadInternalServerError  %+v", 500, o.Payload)
 }
-
-func (o *PutWorkloadInternalServerError) String() string {
-	return fmt.Sprintf("[PUT /workload/v1/stacks/{stack_id}/workloads/{workload_id}][%d] putWorkloadInternalServerError  %+v", 500, o.Payload)
-}
-
 func (o *PutWorkloadInternalServerError) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }
@@ -275,31 +170,6 @@ type PutWorkloadDefault struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this put workload default response has a 2xx status code
-func (o *PutWorkloadDefault) IsSuccess() bool {
-	return o._statusCode/100 == 2
-}
-
-// IsRedirect returns true when this put workload default response has a 3xx status code
-func (o *PutWorkloadDefault) IsRedirect() bool {
-	return o._statusCode/100 == 3
-}
-
-// IsClientError returns true when this put workload default response has a 4xx status code
-func (o *PutWorkloadDefault) IsClientError() bool {
-	return o._statusCode/100 == 4
-}
-
-// IsServerError returns true when this put workload default response has a 5xx status code
-func (o *PutWorkloadDefault) IsServerError() bool {
-	return o._statusCode/100 == 5
-}
-
-// IsCode returns true when this put workload default response a status code equal to that given
-func (o *PutWorkloadDefault) IsCode(code int) bool {
-	return o._statusCode == code
-}
-
 // Code gets the status code for the put workload default response
 func (o *PutWorkloadDefault) Code() int {
 	return o._statusCode
@@ -308,11 +178,6 @@ func (o *PutWorkloadDefault) Code() int {
 func (o *PutWorkloadDefault) Error() string {
 	return fmt.Sprintf("[PUT /workload/v1/stacks/{stack_id}/workloads/{workload_id}][%d] PutWorkload default  %+v", o._statusCode, o.Payload)
 }
-
-func (o *PutWorkloadDefault) String() string {
-	return fmt.Sprintf("[PUT /workload/v1/stacks/{stack_id}/workloads/{workload_id}][%d] PutWorkload default  %+v", o._statusCode, o.Payload)
-}
-
 func (o *PutWorkloadDefault) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }

--- a/stackpath/api/workload/workload_client/workloads/update_workload_responses.go
+++ b/stackpath/api/workload/workload_client/workloads/update_workload_responses.go
@@ -67,44 +67,9 @@ type UpdateWorkloadOK struct {
 	Payload *workload_models.V1UpdateWorkloadResponse
 }
 
-// IsSuccess returns true when this update workload o k response has a 2xx status code
-func (o *UpdateWorkloadOK) IsSuccess() bool {
-	return true
-}
-
-// IsRedirect returns true when this update workload o k response has a 3xx status code
-func (o *UpdateWorkloadOK) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this update workload o k response has a 4xx status code
-func (o *UpdateWorkloadOK) IsClientError() bool {
-	return false
-}
-
-// IsServerError returns true when this update workload o k response has a 5xx status code
-func (o *UpdateWorkloadOK) IsServerError() bool {
-	return false
-}
-
-// IsCode returns true when this update workload o k response a status code equal to that given
-func (o *UpdateWorkloadOK) IsCode(code int) bool {
-	return code == 200
-}
-
-// Code gets the status code for the update workload o k response
-func (o *UpdateWorkloadOK) Code() int {
-	return 200
-}
-
 func (o *UpdateWorkloadOK) Error() string {
 	return fmt.Sprintf("[PATCH /workload/v1/stacks/{stack_id}/workloads/{workload_id}][%d] updateWorkloadOK  %+v", 200, o.Payload)
 }
-
-func (o *UpdateWorkloadOK) String() string {
-	return fmt.Sprintf("[PATCH /workload/v1/stacks/{stack_id}/workloads/{workload_id}][%d] updateWorkloadOK  %+v", 200, o.Payload)
-}
-
 func (o *UpdateWorkloadOK) GetPayload() *workload_models.V1UpdateWorkloadResponse {
 	return o.Payload
 }
@@ -135,44 +100,9 @@ type UpdateWorkloadUnauthorized struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this update workload unauthorized response has a 2xx status code
-func (o *UpdateWorkloadUnauthorized) IsSuccess() bool {
-	return false
-}
-
-// IsRedirect returns true when this update workload unauthorized response has a 3xx status code
-func (o *UpdateWorkloadUnauthorized) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this update workload unauthorized response has a 4xx status code
-func (o *UpdateWorkloadUnauthorized) IsClientError() bool {
-	return true
-}
-
-// IsServerError returns true when this update workload unauthorized response has a 5xx status code
-func (o *UpdateWorkloadUnauthorized) IsServerError() bool {
-	return false
-}
-
-// IsCode returns true when this update workload unauthorized response a status code equal to that given
-func (o *UpdateWorkloadUnauthorized) IsCode(code int) bool {
-	return code == 401
-}
-
-// Code gets the status code for the update workload unauthorized response
-func (o *UpdateWorkloadUnauthorized) Code() int {
-	return 401
-}
-
 func (o *UpdateWorkloadUnauthorized) Error() string {
 	return fmt.Sprintf("[PATCH /workload/v1/stacks/{stack_id}/workloads/{workload_id}][%d] updateWorkloadUnauthorized  %+v", 401, o.Payload)
 }
-
-func (o *UpdateWorkloadUnauthorized) String() string {
-	return fmt.Sprintf("[PATCH /workload/v1/stacks/{stack_id}/workloads/{workload_id}][%d] updateWorkloadUnauthorized  %+v", 401, o.Payload)
-}
-
 func (o *UpdateWorkloadUnauthorized) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }
@@ -203,44 +133,9 @@ type UpdateWorkloadInternalServerError struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this update workload internal server error response has a 2xx status code
-func (o *UpdateWorkloadInternalServerError) IsSuccess() bool {
-	return false
-}
-
-// IsRedirect returns true when this update workload internal server error response has a 3xx status code
-func (o *UpdateWorkloadInternalServerError) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this update workload internal server error response has a 4xx status code
-func (o *UpdateWorkloadInternalServerError) IsClientError() bool {
-	return false
-}
-
-// IsServerError returns true when this update workload internal server error response has a 5xx status code
-func (o *UpdateWorkloadInternalServerError) IsServerError() bool {
-	return true
-}
-
-// IsCode returns true when this update workload internal server error response a status code equal to that given
-func (o *UpdateWorkloadInternalServerError) IsCode(code int) bool {
-	return code == 500
-}
-
-// Code gets the status code for the update workload internal server error response
-func (o *UpdateWorkloadInternalServerError) Code() int {
-	return 500
-}
-
 func (o *UpdateWorkloadInternalServerError) Error() string {
 	return fmt.Sprintf("[PATCH /workload/v1/stacks/{stack_id}/workloads/{workload_id}][%d] updateWorkloadInternalServerError  %+v", 500, o.Payload)
 }
-
-func (o *UpdateWorkloadInternalServerError) String() string {
-	return fmt.Sprintf("[PATCH /workload/v1/stacks/{stack_id}/workloads/{workload_id}][%d] updateWorkloadInternalServerError  %+v", 500, o.Payload)
-}
-
 func (o *UpdateWorkloadInternalServerError) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }
@@ -275,31 +170,6 @@ type UpdateWorkloadDefault struct {
 	Payload *workload_models.StackpathapiStatus
 }
 
-// IsSuccess returns true when this update workload default response has a 2xx status code
-func (o *UpdateWorkloadDefault) IsSuccess() bool {
-	return o._statusCode/100 == 2
-}
-
-// IsRedirect returns true when this update workload default response has a 3xx status code
-func (o *UpdateWorkloadDefault) IsRedirect() bool {
-	return o._statusCode/100 == 3
-}
-
-// IsClientError returns true when this update workload default response has a 4xx status code
-func (o *UpdateWorkloadDefault) IsClientError() bool {
-	return o._statusCode/100 == 4
-}
-
-// IsServerError returns true when this update workload default response has a 5xx status code
-func (o *UpdateWorkloadDefault) IsServerError() bool {
-	return o._statusCode/100 == 5
-}
-
-// IsCode returns true when this update workload default response a status code equal to that given
-func (o *UpdateWorkloadDefault) IsCode(code int) bool {
-	return o._statusCode == code
-}
-
 // Code gets the status code for the update workload default response
 func (o *UpdateWorkloadDefault) Code() int {
 	return o._statusCode
@@ -308,11 +178,6 @@ func (o *UpdateWorkloadDefault) Code() int {
 func (o *UpdateWorkloadDefault) Error() string {
 	return fmt.Sprintf("[PATCH /workload/v1/stacks/{stack_id}/workloads/{workload_id}][%d] UpdateWorkload default  %+v", o._statusCode, o.Payload)
 }
-
-func (o *UpdateWorkloadDefault) String() string {
-	return fmt.Sprintf("[PATCH /workload/v1/stacks/{stack_id}/workloads/{workload_id}][%d] UpdateWorkload default  %+v", o._statusCode, o.Payload)
-}
-
 func (o *UpdateWorkloadDefault) GetPayload() *workload_models.StackpathapiStatus {
 	return o.Payload
 }

--- a/stackpath/api/workload/workload_models/api_status_detail.go
+++ b/stackpath/api/workload/workload_models/api_status_detail.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"io/ioutil"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
@@ -29,7 +30,7 @@ type APIStatusDetail interface {
 	AtType() string
 	SetAtType(string)
 
-	// AdditionalProperties in base type should be handled just like regular properties
+	// AdditionalProperties in base type shoud be handled just like regular properties
 	// At this moment, the base type property is pushed down to the subtype
 }
 
@@ -67,7 +68,7 @@ func UnmarshalAPIStatusDetailSlice(reader io.Reader, consumer runtime.Consumer) 
 // UnmarshalAPIStatusDetail unmarshals polymorphic APIStatusDetail
 func UnmarshalAPIStatusDetail(reader io.Reader, consumer runtime.Consumer) (APIStatusDetail, error) {
 	// we need to read this twice, so first into a buffer
-	data, err := io.ReadAll(reader)
+	data, err := ioutil.ReadAll(reader)
 	if err != nil {
 		return nil, err
 	}

--- a/stackpath/api/workload/workload_models/data_matrix.go
+++ b/stackpath/api/workload/workload_models/data_matrix.go
@@ -51,8 +51,6 @@ func (m *DataMatrix) validateResults(formats strfmt.Registry) error {
 			if err := m.Results[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("results" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}
@@ -82,16 +80,9 @@ func (m *DataMatrix) contextValidateResults(ctx context.Context, formats strfmt.
 	for i := 0; i < len(m.Results); i++ {
 
 		if m.Results[i] != nil {
-
-			if swag.IsZero(m.Results[i]) { // not required
-				return nil
-			}
-
 			if err := m.Results[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("results" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}

--- a/stackpath/api/workload/workload_models/data_matrix_result.go
+++ b/stackpath/api/workload/workload_models/data_matrix_result.go
@@ -54,8 +54,6 @@ func (m *DataMatrixResult) validateValues(formats strfmt.Registry) error {
 			if err := m.Values[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("values" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}
@@ -85,16 +83,9 @@ func (m *DataMatrixResult) contextValidateValues(ctx context.Context, formats st
 	for i := 0; i < len(m.Values); i++ {
 
 		if m.Values[i] != nil {
-
-			if swag.IsZero(m.Values[i]) { // not required
-				return nil
-			}
-
 			if err := m.Values[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("values" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}

--- a/stackpath/api/workload/workload_models/data_vector.go
+++ b/stackpath/api/workload/workload_models/data_vector.go
@@ -51,8 +51,6 @@ func (m *DataVector) validateResults(formats strfmt.Registry) error {
 			if err := m.Results[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("results" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}
@@ -82,16 +80,9 @@ func (m *DataVector) contextValidateResults(ctx context.Context, formats strfmt.
 	for i := 0; i < len(m.Results); i++ {
 
 		if m.Results[i] != nil {
-
-			if swag.IsZero(m.Results[i]) { // not required
-				return nil
-			}
-
 			if err := m.Results[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("results" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}

--- a/stackpath/api/workload/workload_models/data_vector_result.go
+++ b/stackpath/api/workload/workload_models/data_vector_result.go
@@ -48,8 +48,6 @@ func (m *DataVectorResult) validateValue(formats strfmt.Registry) error {
 		if err := m.Value.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("value")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -75,16 +73,9 @@ func (m *DataVectorResult) ContextValidate(ctx context.Context, formats strfmt.R
 func (m *DataVectorResult) contextValidateValue(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Value != nil {
-
-		if swag.IsZero(m.Value) { // not required
-			return nil
-		}
-
 		if err := m.Value.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("value")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}

--- a/stackpath/api/workload/workload_models/metrics_data.go
+++ b/stackpath/api/workload/workload_models/metrics_data.go
@@ -52,8 +52,6 @@ func (m *MetricsData) validateMatrix(formats strfmt.Registry) error {
 		if err := m.Matrix.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("matrix")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -71,8 +69,6 @@ func (m *MetricsData) validateVector(formats strfmt.Registry) error {
 		if err := m.Vector.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("vector")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -102,16 +98,9 @@ func (m *MetricsData) ContextValidate(ctx context.Context, formats strfmt.Regist
 func (m *MetricsData) contextValidateMatrix(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Matrix != nil {
-
-		if swag.IsZero(m.Matrix) { // not required
-			return nil
-		}
-
 		if err := m.Matrix.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("matrix")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -123,16 +112,9 @@ func (m *MetricsData) contextValidateMatrix(ctx context.Context, formats strfmt.
 func (m *MetricsData) contextValidateVector(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Vector != nil {
-
-		if swag.IsZero(m.Vector) { // not required
-			return nil
-		}
-
 		if err := m.Vector.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("vector")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}

--- a/stackpath/api/workload/workload_models/prometheus_metrics.go
+++ b/stackpath/api/workload/workload_models/prometheus_metrics.go
@@ -61,8 +61,6 @@ func (m *PrometheusMetrics) validateData(formats strfmt.Registry) error {
 		if err := m.Data.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -80,8 +78,6 @@ func (m *PrometheusMetrics) validateStatus(formats strfmt.Registry) error {
 		if err := m.Status.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("status")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -111,16 +107,9 @@ func (m *PrometheusMetrics) ContextValidate(ctx context.Context, formats strfmt.
 func (m *PrometheusMetrics) contextValidateData(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Data != nil {
-
-		if swag.IsZero(m.Data) { // not required
-			return nil
-		}
-
 		if err := m.Data.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -132,16 +121,9 @@ func (m *PrometheusMetrics) contextValidateData(ctx context.Context, formats str
 func (m *PrometheusMetrics) contextValidateStatus(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Status != nil {
-
-		if swag.IsZero(m.Status) { // not required
-			return nil
-		}
-
 		if err := m.Status.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("status")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}

--- a/stackpath/api/workload/workload_models/prometheus_metrics_status.go
+++ b/stackpath/api/workload/workload_models/prometheus_metrics_status.go
@@ -20,12 +20,8 @@ import (
 type PrometheusMetricsStatus string
 
 func NewPrometheusMetricsStatus(value PrometheusMetricsStatus) *PrometheusMetricsStatus {
-	return &value
-}
-
-// Pointer returns a pointer to a freshly-allocated PrometheusMetricsStatus.
-func (m PrometheusMetricsStatus) Pointer() *PrometheusMetricsStatus {
-	return &m
+	v := value
+	return &v
 }
 
 const (

--- a/stackpath/api/workload/workload_models/stackpath_rpc_bad_request.go
+++ b/stackpath/api/workload/workload_models/stackpath_rpc_bad_request.go
@@ -133,8 +133,6 @@ func (m *StackpathRPCBadRequest) validateFieldViolations(formats strfmt.Registry
 			if err := m.FieldViolations[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("fieldViolations" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}
@@ -164,16 +162,9 @@ func (m *StackpathRPCBadRequest) contextValidateFieldViolations(ctx context.Cont
 	for i := 0; i < len(m.FieldViolations); i++ {
 
 		if m.FieldViolations[i] != nil {
-
-			if swag.IsZero(m.FieldViolations[i]) { // not required
-				return nil
-			}
-
 			if err := m.FieldViolations[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("fieldViolations" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}

--- a/stackpath/api/workload/workload_models/stackpath_rpc_help.go
+++ b/stackpath/api/workload/workload_models/stackpath_rpc_help.go
@@ -133,8 +133,6 @@ func (m *StackpathRPCHelp) validateLinks(formats strfmt.Registry) error {
 			if err := m.Links[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("links" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}
@@ -164,16 +162,9 @@ func (m *StackpathRPCHelp) contextValidateLinks(ctx context.Context, formats str
 	for i := 0; i < len(m.Links); i++ {
 
 		if m.Links[i] != nil {
-
-			if swag.IsZero(m.Links[i]) { // not required
-				return nil
-			}
-
 			if err := m.Links[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("links" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}

--- a/stackpath/api/workload/workload_models/stackpath_rpc_precondition_failure.go
+++ b/stackpath/api/workload/workload_models/stackpath_rpc_precondition_failure.go
@@ -133,8 +133,6 @@ func (m *StackpathRPCPreconditionFailure) validateViolations(formats strfmt.Regi
 			if err := m.Violations[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("violations" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}
@@ -164,16 +162,9 @@ func (m *StackpathRPCPreconditionFailure) contextValidateViolations(ctx context.
 	for i := 0; i < len(m.Violations); i++ {
 
 		if m.Violations[i] != nil {
-
-			if swag.IsZero(m.Violations[i]) { // not required
-				return nil
-			}
-
 			if err := m.Violations[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("violations" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}

--- a/stackpath/api/workload/workload_models/stackpath_rpc_quota_failure.go
+++ b/stackpath/api/workload/workload_models/stackpath_rpc_quota_failure.go
@@ -133,8 +133,6 @@ func (m *StackpathRPCQuotaFailure) validateViolations(formats strfmt.Registry) e
 			if err := m.Violations[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("violations" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}
@@ -164,16 +162,9 @@ func (m *StackpathRPCQuotaFailure) contextValidateViolations(ctx context.Context
 	for i := 0; i < len(m.Violations); i++ {
 
 		if m.Violations[i] != nil {
-
-			if swag.IsZero(m.Violations[i]) { // not required
-				return nil
-			}
-
 			if err := m.Violations[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("violations" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}

--- a/stackpath/api/workload/workload_models/stackpathapi_status.go
+++ b/stackpath/api/workload/workload_models/stackpathapi_status.go
@@ -138,8 +138,6 @@ func (m *StackpathapiStatus) validateDetails(formats strfmt.Registry) error {
 		if err := m.detailsField[i].Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("details" + "." + strconv.Itoa(i))
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -167,15 +165,9 @@ func (m *StackpathapiStatus) contextValidateDetails(ctx context.Context, formats
 
 	for i := 0; i < len(m.Details()); i++ {
 
-		if swag.IsZero(m.detailsField[i]) { // not required
-			return nil
-		}
-
 		if err := m.detailsField[i].ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("details" + "." + strconv.Itoa(i))
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}

--- a/stackpath/api/workload/workload_models/v1_container_image_pull_policy.go
+++ b/stackpath/api/workload/workload_models/v1_container_image_pull_policy.go
@@ -20,12 +20,8 @@ import (
 type V1ContainerImagePullPolicy string
 
 func NewV1ContainerImagePullPolicy(value V1ContainerImagePullPolicy) *V1ContainerImagePullPolicy {
-	return &value
-}
-
-// Pointer returns a pointer to a freshly-allocated V1ContainerImagePullPolicy.
-func (m V1ContainerImagePullPolicy) Pointer() *V1ContainerImagePullPolicy {
-	return &m
+	v := value
+	return &v
 }
 
 const (

--- a/stackpath/api/workload/workload_models/v1_container_lifecycle.go
+++ b/stackpath/api/workload/workload_models/v1_container_lifecycle.go
@@ -52,8 +52,6 @@ func (m *V1ContainerLifecycle) validatePostStart(formats strfmt.Registry) error 
 		if err := m.PostStart.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("postStart")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -71,8 +69,6 @@ func (m *V1ContainerLifecycle) validatePreStop(formats strfmt.Registry) error {
 		if err := m.PreStop.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("preStop")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -102,16 +98,9 @@ func (m *V1ContainerLifecycle) ContextValidate(ctx context.Context, formats strf
 func (m *V1ContainerLifecycle) contextValidatePostStart(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.PostStart != nil {
-
-		if swag.IsZero(m.PostStart) { // not required
-			return nil
-		}
-
 		if err := m.PostStart.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("postStart")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -123,16 +112,9 @@ func (m *V1ContainerLifecycle) contextValidatePostStart(ctx context.Context, for
 func (m *V1ContainerLifecycle) contextValidatePreStop(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.PreStop != nil {
-
-		if swag.IsZero(m.PreStop) { // not required
-			return nil
-		}
-
 		if err := m.PreStop.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("preStop")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}

--- a/stackpath/api/workload/workload_models/v1_container_lifecycle_handler.go
+++ b/stackpath/api/workload/workload_models/v1_container_lifecycle_handler.go
@@ -59,8 +59,6 @@ func (m *V1ContainerLifecycleHandler) validateExec(formats strfmt.Registry) erro
 		if err := m.Exec.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("exec")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -78,8 +76,6 @@ func (m *V1ContainerLifecycleHandler) validateHTTPGet(formats strfmt.Registry) e
 		if err := m.HTTPGet.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("httpGet")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -97,8 +93,6 @@ func (m *V1ContainerLifecycleHandler) validateTCPSocket(formats strfmt.Registry)
 		if err := m.TCPSocket.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("tcpSocket")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -132,16 +126,9 @@ func (m *V1ContainerLifecycleHandler) ContextValidate(ctx context.Context, forma
 func (m *V1ContainerLifecycleHandler) contextValidateExec(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Exec != nil {
-
-		if swag.IsZero(m.Exec) { // not required
-			return nil
-		}
-
 		if err := m.Exec.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("exec")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -153,16 +140,9 @@ func (m *V1ContainerLifecycleHandler) contextValidateExec(ctx context.Context, f
 func (m *V1ContainerLifecycleHandler) contextValidateHTTPGet(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.HTTPGet != nil {
-
-		if swag.IsZero(m.HTTPGet) { // not required
-			return nil
-		}
-
 		if err := m.HTTPGet.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("httpGet")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -174,16 +154,9 @@ func (m *V1ContainerLifecycleHandler) contextValidateHTTPGet(ctx context.Context
 func (m *V1ContainerLifecycleHandler) contextValidateTCPSocket(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.TCPSocket != nil {
-
-		if swag.IsZero(m.TCPSocket) { // not required
-			return nil
-		}
-
 		if err := m.TCPSocket.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("tcpSocket")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}

--- a/stackpath/api/workload/workload_models/v1_container_security_context.go
+++ b/stackpath/api/workload/workload_models/v1_container_security_context.go
@@ -60,8 +60,6 @@ func (m *V1ContainerSecurityContext) validateCapabilities(formats strfmt.Registr
 		if err := m.Capabilities.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("capabilities")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -87,16 +85,9 @@ func (m *V1ContainerSecurityContext) ContextValidate(ctx context.Context, format
 func (m *V1ContainerSecurityContext) contextValidateCapabilities(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Capabilities != nil {
-
-		if swag.IsZero(m.Capabilities) { // not required
-			return nil
-		}
-
 		if err := m.Capabilities.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("capabilities")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}

--- a/stackpath/api/workload/workload_models/v1_container_spec.go
+++ b/stackpath/api/workload/workload_models/v1_container_spec.go
@@ -131,8 +131,6 @@ func (m *V1ContainerSpec) validateEnv(formats strfmt.Registry) error {
 		if err := m.Env.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("env")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -150,8 +148,6 @@ func (m *V1ContainerSpec) validateImagePullPolicy(formats strfmt.Registry) error
 		if err := m.ImagePullPolicy.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("imagePullPolicy")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -169,8 +165,6 @@ func (m *V1ContainerSpec) validateLifecycle(formats strfmt.Registry) error {
 		if err := m.Lifecycle.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("lifecycle")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -188,8 +182,6 @@ func (m *V1ContainerSpec) validateLivenessProbe(formats strfmt.Registry) error {
 		if err := m.LivenessProbe.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("livenessProbe")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -207,8 +199,6 @@ func (m *V1ContainerSpec) validatePorts(formats strfmt.Registry) error {
 		if err := m.Ports.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("ports")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -226,8 +216,6 @@ func (m *V1ContainerSpec) validateReadinessProbe(formats strfmt.Registry) error 
 		if err := m.ReadinessProbe.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("readinessProbe")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -245,8 +233,6 @@ func (m *V1ContainerSpec) validateResources(formats strfmt.Registry) error {
 		if err := m.Resources.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("resources")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -264,8 +250,6 @@ func (m *V1ContainerSpec) validateSecurityContext(formats strfmt.Registry) error
 		if err := m.SecurityContext.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("securityContext")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -283,8 +267,6 @@ func (m *V1ContainerSpec) validateStartupProbe(formats strfmt.Registry) error {
 		if err := m.StartupProbe.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("startupProbe")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -302,8 +284,6 @@ func (m *V1ContainerSpec) validateTerminationMessagePolicy(formats strfmt.Regist
 		if err := m.TerminationMessagePolicy.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("terminationMessagePolicy")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -326,8 +306,6 @@ func (m *V1ContainerSpec) validateVolumeMounts(formats strfmt.Registry) error {
 			if err := m.VolumeMounts[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("volumeMounts" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}
@@ -394,15 +372,9 @@ func (m *V1ContainerSpec) ContextValidate(ctx context.Context, formats strfmt.Re
 
 func (m *V1ContainerSpec) contextValidateEnv(ctx context.Context, formats strfmt.Registry) error {
 
-	if swag.IsZero(m.Env) { // not required
-		return nil
-	}
-
 	if err := m.Env.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("env")
-		} else if ce, ok := err.(*errors.CompositeError); ok {
-			return ce
 		}
 		return err
 	}
@@ -413,16 +385,9 @@ func (m *V1ContainerSpec) contextValidateEnv(ctx context.Context, formats strfmt
 func (m *V1ContainerSpec) contextValidateImagePullPolicy(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.ImagePullPolicy != nil {
-
-		if swag.IsZero(m.ImagePullPolicy) { // not required
-			return nil
-		}
-
 		if err := m.ImagePullPolicy.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("imagePullPolicy")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -434,16 +399,9 @@ func (m *V1ContainerSpec) contextValidateImagePullPolicy(ctx context.Context, fo
 func (m *V1ContainerSpec) contextValidateLifecycle(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Lifecycle != nil {
-
-		if swag.IsZero(m.Lifecycle) { // not required
-			return nil
-		}
-
 		if err := m.Lifecycle.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("lifecycle")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -455,16 +413,9 @@ func (m *V1ContainerSpec) contextValidateLifecycle(ctx context.Context, formats 
 func (m *V1ContainerSpec) contextValidateLivenessProbe(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.LivenessProbe != nil {
-
-		if swag.IsZero(m.LivenessProbe) { // not required
-			return nil
-		}
-
 		if err := m.LivenessProbe.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("livenessProbe")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -475,15 +426,9 @@ func (m *V1ContainerSpec) contextValidateLivenessProbe(ctx context.Context, form
 
 func (m *V1ContainerSpec) contextValidatePorts(ctx context.Context, formats strfmt.Registry) error {
 
-	if swag.IsZero(m.Ports) { // not required
-		return nil
-	}
-
 	if err := m.Ports.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("ports")
-		} else if ce, ok := err.(*errors.CompositeError); ok {
-			return ce
 		}
 		return err
 	}
@@ -494,16 +439,9 @@ func (m *V1ContainerSpec) contextValidatePorts(ctx context.Context, formats strf
 func (m *V1ContainerSpec) contextValidateReadinessProbe(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.ReadinessProbe != nil {
-
-		if swag.IsZero(m.ReadinessProbe) { // not required
-			return nil
-		}
-
 		if err := m.ReadinessProbe.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("readinessProbe")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -515,16 +453,9 @@ func (m *V1ContainerSpec) contextValidateReadinessProbe(ctx context.Context, for
 func (m *V1ContainerSpec) contextValidateResources(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Resources != nil {
-
-		if swag.IsZero(m.Resources) { // not required
-			return nil
-		}
-
 		if err := m.Resources.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("resources")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -536,16 +467,9 @@ func (m *V1ContainerSpec) contextValidateResources(ctx context.Context, formats 
 func (m *V1ContainerSpec) contextValidateSecurityContext(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.SecurityContext != nil {
-
-		if swag.IsZero(m.SecurityContext) { // not required
-			return nil
-		}
-
 		if err := m.SecurityContext.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("securityContext")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -557,16 +481,9 @@ func (m *V1ContainerSpec) contextValidateSecurityContext(ctx context.Context, fo
 func (m *V1ContainerSpec) contextValidateStartupProbe(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.StartupProbe != nil {
-
-		if swag.IsZero(m.StartupProbe) { // not required
-			return nil
-		}
-
 		if err := m.StartupProbe.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("startupProbe")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -578,16 +495,9 @@ func (m *V1ContainerSpec) contextValidateStartupProbe(ctx context.Context, forma
 func (m *V1ContainerSpec) contextValidateTerminationMessagePolicy(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.TerminationMessagePolicy != nil {
-
-		if swag.IsZero(m.TerminationMessagePolicy) { // not required
-			return nil
-		}
-
 		if err := m.TerminationMessagePolicy.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("terminationMessagePolicy")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -601,16 +511,9 @@ func (m *V1ContainerSpec) contextValidateVolumeMounts(ctx context.Context, forma
 	for i := 0; i < len(m.VolumeMounts); i++ {
 
 		if m.VolumeMounts[i] != nil {
-
-			if swag.IsZero(m.VolumeMounts[i]) { // not required
-				return nil
-			}
-
 			if err := m.VolumeMounts[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("volumeMounts" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}

--- a/stackpath/api/workload/workload_models/v1_container_spec_map_entry.go
+++ b/stackpath/api/workload/workload_models/v1_container_spec_map_entry.go
@@ -29,11 +29,6 @@ func (m V1ContainerSpecMapEntry) Validate(formats strfmt.Registry) error {
 		}
 		if val, ok := m[k]; ok {
 			if err := val.Validate(formats); err != nil {
-				if ve, ok := err.(*errors.Validation); ok {
-					return ve.ValidateName(k)
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
-				}
 				return err
 			}
 		}

--- a/stackpath/api/workload/workload_models/v1_container_status.go
+++ b/stackpath/api/workload/workload_models/v1_container_status.go
@@ -107,8 +107,6 @@ func (m *V1ContainerStatus) validatePhase(formats strfmt.Registry) error {
 		if err := m.Phase.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("phase")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -126,8 +124,6 @@ func (m *V1ContainerStatus) validateRunning(formats strfmt.Registry) error {
 		if err := m.Running.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("running")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -157,8 +153,6 @@ func (m *V1ContainerStatus) validateTerminated(formats strfmt.Registry) error {
 		if err := m.Terminated.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("terminated")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -176,8 +170,6 @@ func (m *V1ContainerStatus) validateWaiting(formats strfmt.Registry) error {
 		if err := m.Waiting.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("waiting")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -215,16 +207,9 @@ func (m *V1ContainerStatus) ContextValidate(ctx context.Context, formats strfmt.
 func (m *V1ContainerStatus) contextValidatePhase(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Phase != nil {
-
-		if swag.IsZero(m.Phase) { // not required
-			return nil
-		}
-
 		if err := m.Phase.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("phase")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -236,16 +221,9 @@ func (m *V1ContainerStatus) contextValidatePhase(ctx context.Context, formats st
 func (m *V1ContainerStatus) contextValidateRunning(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Running != nil {
-
-		if swag.IsZero(m.Running) { // not required
-			return nil
-		}
-
 		if err := m.Running.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("running")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -257,16 +235,9 @@ func (m *V1ContainerStatus) contextValidateRunning(ctx context.Context, formats 
 func (m *V1ContainerStatus) contextValidateTerminated(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Terminated != nil {
-
-		if swag.IsZero(m.Terminated) { // not required
-			return nil
-		}
-
 		if err := m.Terminated.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("terminated")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -278,16 +249,9 @@ func (m *V1ContainerStatus) contextValidateTerminated(ctx context.Context, forma
 func (m *V1ContainerStatus) contextValidateWaiting(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Waiting != nil {
-
-		if swag.IsZero(m.Waiting) { // not required
-			return nil
-		}
-
 		if err := m.Waiting.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("waiting")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}

--- a/stackpath/api/workload/workload_models/v1_container_status_container_phase.go
+++ b/stackpath/api/workload/workload_models/v1_container_status_container_phase.go
@@ -26,12 +26,8 @@ import (
 type V1ContainerStatusContainerPhase string
 
 func NewV1ContainerStatusContainerPhase(value V1ContainerStatusContainerPhase) *V1ContainerStatusContainerPhase {
-	return &value
-}
-
-// Pointer returns a pointer to a freshly-allocated V1ContainerStatusContainerPhase.
-func (m V1ContainerStatusContainerPhase) Pointer() *V1ContainerStatusContainerPhase {
-	return &m
+	v := value
+	return &v
 }
 
 const (

--- a/stackpath/api/workload/workload_models/v1_container_termination_message_policy.go
+++ b/stackpath/api/workload/workload_models/v1_container_termination_message_policy.go
@@ -20,12 +20,8 @@ import (
 type V1ContainerTerminationMessagePolicy string
 
 func NewV1ContainerTerminationMessagePolicy(value V1ContainerTerminationMessagePolicy) *V1ContainerTerminationMessagePolicy {
-	return &value
-}
-
-// Pointer returns a pointer to a freshly-allocated V1ContainerTerminationMessagePolicy.
-func (m V1ContainerTerminationMessagePolicy) Pointer() *V1ContainerTerminationMessagePolicy {
-	return &m
+	v := value
+	return &v
 }
 
 const (

--- a/stackpath/api/workload/workload_models/v1_create_image_request.go
+++ b/stackpath/api/workload/workload_models/v1_create_image_request.go
@@ -52,8 +52,6 @@ func (m *V1CreateImageRequest) validateImage(formats strfmt.Registry) error {
 		if err := m.Image.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("image")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -71,8 +69,6 @@ func (m *V1CreateImageRequest) validateInstanceVolumeSource(formats strfmt.Regis
 		if err := m.InstanceVolumeSource.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("instanceVolumeSource")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -102,16 +98,9 @@ func (m *V1CreateImageRequest) ContextValidate(ctx context.Context, formats strf
 func (m *V1CreateImageRequest) contextValidateImage(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Image != nil {
-
-		if swag.IsZero(m.Image) { // not required
-			return nil
-		}
-
 		if err := m.Image.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("image")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -123,16 +112,9 @@ func (m *V1CreateImageRequest) contextValidateImage(ctx context.Context, formats
 func (m *V1CreateImageRequest) contextValidateInstanceVolumeSource(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.InstanceVolumeSource != nil {
-
-		if swag.IsZero(m.InstanceVolumeSource) { // not required
-			return nil
-		}
-
 		if err := m.InstanceVolumeSource.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("instanceVolumeSource")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}

--- a/stackpath/api/workload/workload_models/v1_create_image_response.go
+++ b/stackpath/api/workload/workload_models/v1_create_image_response.go
@@ -45,8 +45,6 @@ func (m *V1CreateImageResponse) validateImage(formats strfmt.Registry) error {
 		if err := m.Image.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("image")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -72,16 +70,9 @@ func (m *V1CreateImageResponse) ContextValidate(ctx context.Context, formats str
 func (m *V1CreateImageResponse) contextValidateImage(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Image != nil {
-
-		if swag.IsZero(m.Image) { // not required
-			return nil
-		}
-
 		if err := m.Image.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("image")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}

--- a/stackpath/api/workload/workload_models/v1_create_workload_request.go
+++ b/stackpath/api/workload/workload_models/v1_create_workload_request.go
@@ -45,8 +45,6 @@ func (m *V1CreateWorkloadRequest) validateWorkload(formats strfmt.Registry) erro
 		if err := m.Workload.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("workload")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -72,16 +70,9 @@ func (m *V1CreateWorkloadRequest) ContextValidate(ctx context.Context, formats s
 func (m *V1CreateWorkloadRequest) contextValidateWorkload(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Workload != nil {
-
-		if swag.IsZero(m.Workload) { // not required
-			return nil
-		}
-
 		if err := m.Workload.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("workload")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}

--- a/stackpath/api/workload/workload_models/v1_create_workload_response.go
+++ b/stackpath/api/workload/workload_models/v1_create_workload_response.go
@@ -45,8 +45,6 @@ func (m *V1CreateWorkloadResponse) validateWorkload(formats strfmt.Registry) err
 		if err := m.Workload.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("workload")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -72,16 +70,9 @@ func (m *V1CreateWorkloadResponse) ContextValidate(ctx context.Context, formats 
 func (m *V1CreateWorkloadResponse) contextValidateWorkload(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Workload != nil {
-
-		if swag.IsZero(m.Workload) { // not required
-			return nil
-		}
-
 		if err := m.Workload.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("workload")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}

--- a/stackpath/api/workload/workload_models/v1_deployment_spec.go
+++ b/stackpath/api/workload/workload_models/v1_deployment_spec.go
@@ -59,8 +59,6 @@ func (m *V1DeploymentSpec) validateScaleSettings(formats strfmt.Registry) error 
 		if err := m.ScaleSettings.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("scaleSettings")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -83,8 +81,6 @@ func (m *V1DeploymentSpec) validateSelectors(formats strfmt.Registry) error {
 			if err := m.Selectors[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("selectors" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}
@@ -116,16 +112,9 @@ func (m *V1DeploymentSpec) ContextValidate(ctx context.Context, formats strfmt.R
 func (m *V1DeploymentSpec) contextValidateScaleSettings(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.ScaleSettings != nil {
-
-		if swag.IsZero(m.ScaleSettings) { // not required
-			return nil
-		}
-
 		if err := m.ScaleSettings.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("scaleSettings")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -139,16 +128,9 @@ func (m *V1DeploymentSpec) contextValidateSelectors(ctx context.Context, formats
 	for i := 0; i < len(m.Selectors); i++ {
 
 		if m.Selectors[i] != nil {
-
-			if swag.IsZero(m.Selectors[i]) { // not required
-				return nil
-			}
-
 			if err := m.Selectors[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("selectors" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}

--- a/stackpath/api/workload/workload_models/v1_dns_config.go
+++ b/stackpath/api/workload/workload_models/v1_dns_config.go
@@ -57,8 +57,6 @@ func (m *V1DNSConfig) validateOptions(formats strfmt.Registry) error {
 			if err := m.Options[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("options" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}
@@ -88,16 +86,9 @@ func (m *V1DNSConfig) contextValidateOptions(ctx context.Context, formats strfmt
 	for i := 0; i < len(m.Options); i++ {
 
 		if m.Options[i] != nil {
-
-			if swag.IsZero(m.Options[i]) { // not required
-				return nil
-			}
-
 			if err := m.Options[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("options" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}

--- a/stackpath/api/workload/workload_models/v1_environment_variable.go
+++ b/stackpath/api/workload/workload_models/v1_environment_variable.go
@@ -51,8 +51,6 @@ func (m *V1EnvironmentVariable) validateValueFrom(formats strfmt.Registry) error
 		if err := m.ValueFrom.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("valueFrom")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -78,16 +76,9 @@ func (m *V1EnvironmentVariable) ContextValidate(ctx context.Context, formats str
 func (m *V1EnvironmentVariable) contextValidateValueFrom(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.ValueFrom != nil {
-
-		if swag.IsZero(m.ValueFrom) { // not required
-			return nil
-		}
-
 		if err := m.ValueFrom.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("valueFrom")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}

--- a/stackpath/api/workload/workload_models/v1_environment_variable_map_entry.go
+++ b/stackpath/api/workload/workload_models/v1_environment_variable_map_entry.go
@@ -29,11 +29,6 @@ func (m V1EnvironmentVariableMapEntry) Validate(formats strfmt.Registry) error {
 		}
 		if val, ok := m[k]; ok {
 			if err := val.Validate(formats); err != nil {
-				if ve, ok := err.(*errors.Validation); ok {
-					return ve.ValidateName(k)
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
-				}
 				return err
 			}
 		}

--- a/stackpath/api/workload/workload_models/v1_environment_variable_source.go
+++ b/stackpath/api/workload/workload_models/v1_environment_variable_source.go
@@ -45,8 +45,6 @@ func (m *V1EnvironmentVariableSource) validateInstanceFieldRef(formats strfmt.Re
 		if err := m.InstanceFieldRef.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("instanceFieldRef")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -72,16 +70,9 @@ func (m *V1EnvironmentVariableSource) ContextValidate(ctx context.Context, forma
 func (m *V1EnvironmentVariableSource) contextValidateInstanceFieldRef(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.InstanceFieldRef != nil {
-
-		if swag.IsZero(m.InstanceFieldRef) { // not required
-			return nil
-		}
-
 		if err := m.InstanceFieldRef.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("instanceFieldRef")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}

--- a/stackpath/api/workload/workload_models/v1_get_image_response.go
+++ b/stackpath/api/workload/workload_models/v1_get_image_response.go
@@ -45,8 +45,6 @@ func (m *V1GetImageResponse) validateImage(formats strfmt.Registry) error {
 		if err := m.Image.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("image")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -72,16 +70,9 @@ func (m *V1GetImageResponse) ContextValidate(ctx context.Context, formats strfmt
 func (m *V1GetImageResponse) contextValidateImage(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Image != nil {
-
-		if swag.IsZero(m.Image) { // not required
-			return nil
-		}
-
 		if err := m.Image.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("image")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}

--- a/stackpath/api/workload/workload_models/v1_get_images_for_family_response.go
+++ b/stackpath/api/workload/workload_models/v1_get_images_for_family_response.go
@@ -53,8 +53,6 @@ func (m *V1GetImagesForFamilyResponse) validatePageInfo(formats strfmt.Registry)
 		if err := m.PageInfo.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("pageInfo")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -77,8 +75,6 @@ func (m *V1GetImagesForFamilyResponse) validateResults(formats strfmt.Registry) 
 			if err := m.Results[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("results" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}
@@ -110,16 +106,9 @@ func (m *V1GetImagesForFamilyResponse) ContextValidate(ctx context.Context, form
 func (m *V1GetImagesForFamilyResponse) contextValidatePageInfo(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.PageInfo != nil {
-
-		if swag.IsZero(m.PageInfo) { // not required
-			return nil
-		}
-
 		if err := m.PageInfo.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("pageInfo")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -133,16 +122,9 @@ func (m *V1GetImagesForFamilyResponse) contextValidateResults(ctx context.Contex
 	for i := 0; i < len(m.Results); i++ {
 
 		if m.Results[i] != nil {
-
-			if swag.IsZero(m.Results[i]) { // not required
-				return nil
-			}
-
 			if err := m.Results[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("results" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}

--- a/stackpath/api/workload/workload_models/v1_get_images_response.go
+++ b/stackpath/api/workload/workload_models/v1_get_images_response.go
@@ -53,8 +53,6 @@ func (m *V1GetImagesResponse) validatePageInfo(formats strfmt.Registry) error {
 		if err := m.PageInfo.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("pageInfo")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -77,8 +75,6 @@ func (m *V1GetImagesResponse) validateResults(formats strfmt.Registry) error {
 			if err := m.Results[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("results" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}
@@ -110,16 +106,9 @@ func (m *V1GetImagesResponse) ContextValidate(ctx context.Context, formats strfm
 func (m *V1GetImagesResponse) contextValidatePageInfo(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.PageInfo != nil {
-
-		if swag.IsZero(m.PageInfo) { // not required
-			return nil
-		}
-
 		if err := m.PageInfo.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("pageInfo")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -133,16 +122,9 @@ func (m *V1GetImagesResponse) contextValidateResults(ctx context.Context, format
 	for i := 0; i < len(m.Results); i++ {
 
 		if m.Results[i] != nil {
-
-			if swag.IsZero(m.Results[i]) { // not required
-				return nil
-			}
-
 			if err := m.Results[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("results" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}

--- a/stackpath/api/workload/workload_models/v1_get_locations_response.go
+++ b/stackpath/api/workload/workload_models/v1_get_locations_response.go
@@ -53,8 +53,6 @@ func (m *V1GetLocationsResponse) validatePageInfo(formats strfmt.Registry) error
 		if err := m.PageInfo.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("pageInfo")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -77,8 +75,6 @@ func (m *V1GetLocationsResponse) validateResults(formats strfmt.Registry) error 
 			if err := m.Results[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("results" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}
@@ -110,16 +106,9 @@ func (m *V1GetLocationsResponse) ContextValidate(ctx context.Context, formats st
 func (m *V1GetLocationsResponse) contextValidatePageInfo(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.PageInfo != nil {
-
-		if swag.IsZero(m.PageInfo) { // not required
-			return nil
-		}
-
 		if err := m.PageInfo.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("pageInfo")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -133,16 +122,9 @@ func (m *V1GetLocationsResponse) contextValidateResults(ctx context.Context, for
 	for i := 0; i < len(m.Results); i++ {
 
 		if m.Results[i] != nil {
-
-			if swag.IsZero(m.Results[i]) { // not required
-				return nil
-			}
-
 			if err := m.Results[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("results" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}

--- a/stackpath/api/workload/workload_models/v1_get_workload_instance_response.go
+++ b/stackpath/api/workload/workload_models/v1_get_workload_instance_response.go
@@ -45,8 +45,6 @@ func (m *V1GetWorkloadInstanceResponse) validateInstance(formats strfmt.Registry
 		if err := m.Instance.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("instance")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -72,16 +70,9 @@ func (m *V1GetWorkloadInstanceResponse) ContextValidate(ctx context.Context, for
 func (m *V1GetWorkloadInstanceResponse) contextValidateInstance(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Instance != nil {
-
-		if swag.IsZero(m.Instance) { // not required
-			return nil
-		}
-
 		if err := m.Instance.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("instance")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}

--- a/stackpath/api/workload/workload_models/v1_get_workload_instances_response.go
+++ b/stackpath/api/workload/workload_models/v1_get_workload_instances_response.go
@@ -53,8 +53,6 @@ func (m *V1GetWorkloadInstancesResponse) validatePageInfo(formats strfmt.Registr
 		if err := m.PageInfo.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("pageInfo")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -77,8 +75,6 @@ func (m *V1GetWorkloadInstancesResponse) validateResults(formats strfmt.Registry
 			if err := m.Results[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("results" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}
@@ -110,16 +106,9 @@ func (m *V1GetWorkloadInstancesResponse) ContextValidate(ctx context.Context, fo
 func (m *V1GetWorkloadInstancesResponse) contextValidatePageInfo(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.PageInfo != nil {
-
-		if swag.IsZero(m.PageInfo) { // not required
-			return nil
-		}
-
 		if err := m.PageInfo.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("pageInfo")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -133,16 +122,9 @@ func (m *V1GetWorkloadInstancesResponse) contextValidateResults(ctx context.Cont
 	for i := 0; i < len(m.Results); i++ {
 
 		if m.Results[i] != nil {
-
-			if swag.IsZero(m.Results[i]) { // not required
-				return nil
-			}
-
 			if err := m.Results[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("results" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}

--- a/stackpath/api/workload/workload_models/v1_get_workload_response.go
+++ b/stackpath/api/workload/workload_models/v1_get_workload_response.go
@@ -45,8 +45,6 @@ func (m *V1GetWorkloadResponse) validateWorkload(formats strfmt.Registry) error 
 		if err := m.Workload.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("workload")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -72,16 +70,9 @@ func (m *V1GetWorkloadResponse) ContextValidate(ctx context.Context, formats str
 func (m *V1GetWorkloadResponse) contextValidateWorkload(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Workload != nil {
-
-		if swag.IsZero(m.Workload) { // not required
-			return nil
-		}
-
 		if err := m.Workload.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("workload")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}

--- a/stackpath/api/workload/workload_models/v1_get_workloads_response.go
+++ b/stackpath/api/workload/workload_models/v1_get_workloads_response.go
@@ -53,8 +53,6 @@ func (m *V1GetWorkloadsResponse) validatePageInfo(formats strfmt.Registry) error
 		if err := m.PageInfo.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("pageInfo")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -77,8 +75,6 @@ func (m *V1GetWorkloadsResponse) validateResults(formats strfmt.Registry) error 
 			if err := m.Results[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("results" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}
@@ -110,16 +106,9 @@ func (m *V1GetWorkloadsResponse) ContextValidate(ctx context.Context, formats st
 func (m *V1GetWorkloadsResponse) contextValidatePageInfo(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.PageInfo != nil {
-
-		if swag.IsZero(m.PageInfo) { // not required
-			return nil
-		}
-
 		if err := m.PageInfo.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("pageInfo")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -133,16 +122,9 @@ func (m *V1GetWorkloadsResponse) contextValidateResults(ctx context.Context, for
 	for i := 0; i < len(m.Results); i++ {
 
 		if m.Results[i] != nil {
-
-			if swag.IsZero(m.Results[i]) { // not required
-				return nil
-			}
-
 			if err := m.Results[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("results" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}

--- a/stackpath/api/workload/workload_models/v1_http_get_action.go
+++ b/stackpath/api/workload/workload_models/v1_http_get_action.go
@@ -54,8 +54,6 @@ func (m *V1HTTPGetAction) validateHTTPHeaders(formats strfmt.Registry) error {
 		if err := m.HTTPHeaders.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("httpHeaders")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -80,15 +78,9 @@ func (m *V1HTTPGetAction) ContextValidate(ctx context.Context, formats strfmt.Re
 
 func (m *V1HTTPGetAction) contextValidateHTTPHeaders(ctx context.Context, formats strfmt.Registry) error {
 
-	if swag.IsZero(m.HTTPHeaders) { // not required
-		return nil
-	}
-
 	if err := m.HTTPHeaders.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("httpHeaders")
-		} else if ce, ok := err.(*errors.CompositeError); ok {
-			return ce
 		}
 		return err
 	}

--- a/stackpath/api/workload/workload_models/v1_image.go
+++ b/stackpath/api/workload/workload_models/v1_image.go
@@ -116,8 +116,6 @@ func (m *V1Image) validateConditions(formats strfmt.Registry) error {
 			if err := m.Conditions[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("conditions" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}
@@ -137,8 +135,6 @@ func (m *V1Image) validateDeprecation(formats strfmt.Registry) error {
 		if err := m.Deprecation.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("deprecation")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -156,8 +152,6 @@ func (m *V1Image) validateMetadata(formats strfmt.Registry) error {
 		if err := m.Metadata.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("metadata")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -175,8 +169,6 @@ func (m *V1Image) validateStatus(formats strfmt.Registry) error {
 		if err := m.Status.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("status")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -236,16 +228,9 @@ func (m *V1Image) contextValidateConditions(ctx context.Context, formats strfmt.
 	for i := 0; i < len(m.Conditions); i++ {
 
 		if m.Conditions[i] != nil {
-
-			if swag.IsZero(m.Conditions[i]) { // not required
-				return nil
-			}
-
 			if err := m.Conditions[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("conditions" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}
@@ -259,16 +244,9 @@ func (m *V1Image) contextValidateConditions(ctx context.Context, formats strfmt.
 func (m *V1Image) contextValidateDeprecation(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Deprecation != nil {
-
-		if swag.IsZero(m.Deprecation) { // not required
-			return nil
-		}
-
 		if err := m.Deprecation.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("deprecation")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -298,16 +276,9 @@ func (m *V1Image) contextValidateImageSize(ctx context.Context, formats strfmt.R
 func (m *V1Image) contextValidateMetadata(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Metadata != nil {
-
-		if swag.IsZero(m.Metadata) { // not required
-			return nil
-		}
-
 		if err := m.Metadata.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("metadata")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -328,16 +299,9 @@ func (m *V1Image) contextValidateStackID(ctx context.Context, formats strfmt.Reg
 func (m *V1Image) contextValidateStatus(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Status != nil {
-
-		if swag.IsZero(m.Status) { // not required
-			return nil
-		}
-
 		if err := m.Status.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("status")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}

--- a/stackpath/api/workload/workload_models/v1_image_condition.go
+++ b/stackpath/api/workload/workload_models/v1_image_condition.go
@@ -83,8 +83,6 @@ func (m *V1ImageCondition) validateStatus(formats strfmt.Registry) error {
 		if err := m.Status.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("status")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -122,16 +120,9 @@ func (m *V1ImageCondition) ContextValidate(ctx context.Context, formats strfmt.R
 func (m *V1ImageCondition) contextValidateStatus(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Status != nil {
-
-		if swag.IsZero(m.Status) { // not required
-			return nil
-		}
-
 		if err := m.Status.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("status")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}

--- a/stackpath/api/workload/workload_models/v1_image_condition_status.go
+++ b/stackpath/api/workload/workload_models/v1_image_condition_status.go
@@ -24,12 +24,8 @@ import (
 type V1ImageConditionStatus string
 
 func NewV1ImageConditionStatus(value V1ImageConditionStatus) *V1ImageConditionStatus {
-	return &value
-}
-
-// Pointer returns a pointer to a freshly-allocated V1ImageConditionStatus.
-func (m V1ImageConditionStatus) Pointer() *V1ImageConditionStatus {
-	return &m
+	v := value
+	return &v
 }
 
 const (

--- a/stackpath/api/workload/workload_models/v1_image_metadata.go
+++ b/stackpath/api/workload/workload_models/v1_image_metadata.go
@@ -75,8 +75,6 @@ func (m *V1ImageMetadata) validateAnnotations(formats strfmt.Registry) error {
 		if err := m.Annotations.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("annotations")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -106,8 +104,6 @@ func (m *V1ImageMetadata) validateLabels(formats strfmt.Registry) error {
 		if err := m.Labels.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("labels")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -156,15 +152,9 @@ func (m *V1ImageMetadata) ContextValidate(ctx context.Context, formats strfmt.Re
 
 func (m *V1ImageMetadata) contextValidateAnnotations(ctx context.Context, formats strfmt.Registry) error {
 
-	if swag.IsZero(m.Annotations) { // not required
-		return nil
-	}
-
 	if err := m.Annotations.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("annotations")
-		} else if ce, ok := err.(*errors.CompositeError); ok {
-			return ce
 		}
 		return err
 	}
@@ -183,15 +173,9 @@ func (m *V1ImageMetadata) contextValidateCreatedAt(ctx context.Context, formats 
 
 func (m *V1ImageMetadata) contextValidateLabels(ctx context.Context, formats strfmt.Registry) error {
 
-	if swag.IsZero(m.Labels) { // not required
-		return nil
-	}
-
 	if err := m.Labels.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("labels")
-		} else if ce, ok := err.(*errors.CompositeError); ok {
-			return ce
 		}
 		return err
 	}

--- a/stackpath/api/workload/workload_models/v1_image_pull_credential.go
+++ b/stackpath/api/workload/workload_models/v1_image_pull_credential.go
@@ -45,8 +45,6 @@ func (m *V1ImagePullCredential) validateDockerRegistry(formats strfmt.Registry) 
 		if err := m.DockerRegistry.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("dockerRegistry")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -72,16 +70,9 @@ func (m *V1ImagePullCredential) ContextValidate(ctx context.Context, formats str
 func (m *V1ImagePullCredential) contextValidateDockerRegistry(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.DockerRegistry != nil {
-
-		if swag.IsZero(m.DockerRegistry) { // not required
-			return nil
-		}
-
 		if err := m.DockerRegistry.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("dockerRegistry")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}

--- a/stackpath/api/workload/workload_models/v1_image_status.go
+++ b/stackpath/api/workload/workload_models/v1_image_status.go
@@ -26,12 +26,8 @@ import (
 type V1ImageStatus string
 
 func NewV1ImageStatus(value V1ImageStatus) *V1ImageStatus {
-	return &value
-}
-
-// Pointer returns a pointer to a freshly-allocated V1ImageStatus.
-func (m V1ImageStatus) Pointer() *V1ImageStatus {
-	return &m
+	v := value
+	return &v
 }
 
 const (

--- a/stackpath/api/workload/workload_models/v1_instance_port_map_entry.go
+++ b/stackpath/api/workload/workload_models/v1_instance_port_map_entry.go
@@ -29,11 +29,6 @@ func (m V1InstancePortMapEntry) Validate(formats strfmt.Registry) error {
 		}
 		if val, ok := m[k]; ok {
 			if err := val.Validate(formats); err != nil {
-				if ve, ok := err.(*errors.Validation); ok {
-					return ve.ValidateName(k)
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
-				}
 				return err
 			}
 		}

--- a/stackpath/api/workload/workload_models/v1_ip_family.go
+++ b/stackpath/api/workload/workload_models/v1_ip_family.go
@@ -24,12 +24,8 @@ import (
 type V1IPFamily string
 
 func NewV1IPFamily(value V1IPFamily) *V1IPFamily {
-	return &value
-}
-
-// Pointer returns a pointer to a freshly-allocated V1IPFamily.
-func (m V1IPFamily) Pointer() *V1IPFamily {
-	return &m
+	v := value
+	return &v
 }
 
 const (

--- a/stackpath/api/workload/workload_models/v1_metadata.go
+++ b/stackpath/api/workload/workload_models/v1_metadata.go
@@ -85,8 +85,6 @@ func (m *V1Metadata) validateAnnotations(formats strfmt.Registry) error {
 		if err := m.Annotations.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("annotations")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -128,8 +126,6 @@ func (m *V1Metadata) validateLabels(formats strfmt.Registry) error {
 		if err := m.Labels.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("labels")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -182,15 +178,9 @@ func (m *V1Metadata) ContextValidate(ctx context.Context, formats strfmt.Registr
 
 func (m *V1Metadata) contextValidateAnnotations(ctx context.Context, formats strfmt.Registry) error {
 
-	if swag.IsZero(m.Annotations) { // not required
-		return nil
-	}
-
 	if err := m.Annotations.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("annotations")
-		} else if ce, ok := err.(*errors.CompositeError); ok {
-			return ce
 		}
 		return err
 	}
@@ -218,15 +208,9 @@ func (m *V1Metadata) contextValidateDeleteRequestedAt(ctx context.Context, forma
 
 func (m *V1Metadata) contextValidateLabels(ctx context.Context, formats strfmt.Registry) error {
 
-	if swag.IsZero(m.Labels) { // not required
-		return nil
-	}
-
 	if err := m.Labels.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("labels")
-		} else if ce, ok := err.(*errors.CompositeError); ok {
-			return ce
 		}
 		return err
 	}

--- a/stackpath/api/workload/workload_models/v1_network_interface.go
+++ b/stackpath/api/workload/workload_models/v1_network_interface.go
@@ -25,7 +25,7 @@ type V1NetworkInterface struct {
 	//
 	// Mark this property `false` to disable NAT on the first interface. Mark this property `true` to enable NAT on secondary interfaces.
 	//
-	// The `ExcludeNAT` workload annotation supersedes this property.
+	// The `ExcludeNAT` workload annotation supercedes this property.
 	EnableOneToOneNat bool `json:"enableOneToOneNat,omitempty"`
 
 	// A list of IP families to use for interface ip assignments
@@ -71,8 +71,6 @@ func (m *V1NetworkInterface) validateIPFamilies(formats strfmt.Registry) error {
 			if err := m.IPFamilies[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("ipFamilies" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}
@@ -102,16 +100,9 @@ func (m *V1NetworkInterface) contextValidateIPFamilies(ctx context.Context, form
 	for i := 0; i < len(m.IPFamilies); i++ {
 
 		if m.IPFamilies[i] != nil {
-
-			if swag.IsZero(m.IPFamilies[i]) { // not required
-				return nil
-			}
-
 			if err := m.IPFamilies[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("ipFamilies" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}

--- a/stackpath/api/workload/workload_models/v1_probe.go
+++ b/stackpath/api/workload/workload_models/v1_probe.go
@@ -82,8 +82,6 @@ func (m *V1Probe) validateExec(formats strfmt.Registry) error {
 		if err := m.Exec.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("exec")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -101,8 +99,6 @@ func (m *V1Probe) validateHTTPGet(formats strfmt.Registry) error {
 		if err := m.HTTPGet.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("httpGet")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -120,8 +116,6 @@ func (m *V1Probe) validateTCPSocket(formats strfmt.Registry) error {
 		if err := m.TCPSocket.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("tcpSocket")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -155,16 +149,9 @@ func (m *V1Probe) ContextValidate(ctx context.Context, formats strfmt.Registry) 
 func (m *V1Probe) contextValidateExec(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Exec != nil {
-
-		if swag.IsZero(m.Exec) { // not required
-			return nil
-		}
-
 		if err := m.Exec.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("exec")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -176,16 +163,9 @@ func (m *V1Probe) contextValidateExec(ctx context.Context, formats strfmt.Regist
 func (m *V1Probe) contextValidateHTTPGet(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.HTTPGet != nil {
-
-		if swag.IsZero(m.HTTPGet) { // not required
-			return nil
-		}
-
 		if err := m.HTTPGet.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("httpGet")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -197,16 +177,9 @@ func (m *V1Probe) contextValidateHTTPGet(ctx context.Context, formats strfmt.Reg
 func (m *V1Probe) contextValidateTCPSocket(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.TCPSocket != nil {
-
-		if swag.IsZero(m.TCPSocket) { // not required
-			return nil
-		}
-
 		if err := m.TCPSocket.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("tcpSocket")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}

--- a/stackpath/api/workload/workload_models/v1_put_workload_request.go
+++ b/stackpath/api/workload/workload_models/v1_put_workload_request.go
@@ -45,8 +45,6 @@ func (m *V1PutWorkloadRequest) validateWorkload(formats strfmt.Registry) error {
 		if err := m.Workload.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("workload")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -72,16 +70,9 @@ func (m *V1PutWorkloadRequest) ContextValidate(ctx context.Context, formats strf
 func (m *V1PutWorkloadRequest) contextValidateWorkload(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Workload != nil {
-
-		if swag.IsZero(m.Workload) { // not required
-			return nil
-		}
-
 		if err := m.Workload.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("workload")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}

--- a/stackpath/api/workload/workload_models/v1_put_workload_response.go
+++ b/stackpath/api/workload/workload_models/v1_put_workload_response.go
@@ -45,8 +45,6 @@ func (m *V1PutWorkloadResponse) validateWorkload(formats strfmt.Registry) error 
 		if err := m.Workload.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("workload")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -72,16 +70,9 @@ func (m *V1PutWorkloadResponse) ContextValidate(ctx context.Context, formats str
 func (m *V1PutWorkloadResponse) contextValidateWorkload(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Workload != nil {
-
-		if swag.IsZero(m.Workload) { // not required
-			return nil
-		}
-
 		if err := m.Workload.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("workload")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}

--- a/stackpath/api/workload/workload_models/v1_resource_requirements.go
+++ b/stackpath/api/workload/workload_models/v1_resource_requirements.go
@@ -58,8 +58,6 @@ func (m *V1ResourceRequirements) validateLimits(formats strfmt.Registry) error {
 		if err := m.Limits.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("limits")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -77,8 +75,6 @@ func (m *V1ResourceRequirements) validateRequests(formats strfmt.Registry) error
 		if err := m.Requests.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("requests")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -107,15 +103,9 @@ func (m *V1ResourceRequirements) ContextValidate(ctx context.Context, formats st
 
 func (m *V1ResourceRequirements) contextValidateLimits(ctx context.Context, formats strfmt.Registry) error {
 
-	if swag.IsZero(m.Limits) { // not required
-		return nil
-	}
-
 	if err := m.Limits.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("limits")
-		} else if ce, ok := err.(*errors.CompositeError); ok {
-			return ce
 		}
 		return err
 	}
@@ -125,15 +115,9 @@ func (m *V1ResourceRequirements) contextValidateLimits(ctx context.Context, form
 
 func (m *V1ResourceRequirements) contextValidateRequests(ctx context.Context, formats strfmt.Registry) error {
 
-	if swag.IsZero(m.Requests) { // not required
-		return nil
-	}
-
 	if err := m.Requests.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("requests")
-		} else if ce, ok := err.(*errors.CompositeError); ok {
-			return ce
 		}
 		return err
 	}

--- a/stackpath/api/workload/workload_models/v1_scale_settings.go
+++ b/stackpath/api/workload/workload_models/v1_scale_settings.go
@@ -51,8 +51,6 @@ func (m *V1ScaleSettings) validateMetrics(formats strfmt.Registry) error {
 			if err := m.Metrics[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("metrics" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}
@@ -82,16 +80,9 @@ func (m *V1ScaleSettings) contextValidateMetrics(ctx context.Context, formats st
 	for i := 0; i < len(m.Metrics); i++ {
 
 		if m.Metrics[i] != nil {
-
-			if swag.IsZero(m.Metrics[i]) { // not required
-				return nil
-			}
-
 			if err := m.Metrics[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("metrics" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}

--- a/stackpath/api/workload/workload_models/v1_target.go
+++ b/stackpath/api/workload/workload_models/v1_target.go
@@ -45,8 +45,6 @@ func (m *V1Target) validateSpec(formats strfmt.Registry) error {
 		if err := m.Spec.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("spec")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -72,16 +70,9 @@ func (m *V1Target) ContextValidate(ctx context.Context, formats strfmt.Registry)
 func (m *V1Target) contextValidateSpec(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Spec != nil {
-
-		if swag.IsZero(m.Spec) { // not required
-			return nil
-		}
-
 		if err := m.Spec.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("spec")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}

--- a/stackpath/api/workload/workload_models/v1_target_map_entry.go
+++ b/stackpath/api/workload/workload_models/v1_target_map_entry.go
@@ -29,11 +29,6 @@ func (m V1TargetMapEntry) Validate(formats strfmt.Registry) error {
 		}
 		if val, ok := m[k]; ok {
 			if err := val.Validate(formats); err != nil {
-				if ve, ok := err.(*errors.Validation); ok {
-					return ve.ValidateName(k)
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
-				}
 				return err
 			}
 		}

--- a/stackpath/api/workload/workload_models/v1_target_spec.go
+++ b/stackpath/api/workload/workload_models/v1_target_spec.go
@@ -48,8 +48,6 @@ func (m *V1TargetSpec) validateDeployments(formats strfmt.Registry) error {
 		if err := m.Deployments.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("deployments")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -75,16 +73,9 @@ func (m *V1TargetSpec) ContextValidate(ctx context.Context, formats strfmt.Regis
 func (m *V1TargetSpec) contextValidateDeployments(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Deployments != nil {
-
-		if swag.IsZero(m.Deployments) { // not required
-			return nil
-		}
-
 		if err := m.Deployments.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("deployments")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}

--- a/stackpath/api/workload/workload_models/v1_update_image_deprecation_response.go
+++ b/stackpath/api/workload/workload_models/v1_update_image_deprecation_response.go
@@ -45,8 +45,6 @@ func (m *V1UpdateImageDeprecationResponse) validateImage(formats strfmt.Registry
 		if err := m.Image.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("image")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -72,16 +70,9 @@ func (m *V1UpdateImageDeprecationResponse) ContextValidate(ctx context.Context, 
 func (m *V1UpdateImageDeprecationResponse) contextValidateImage(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Image != nil {
-
-		if swag.IsZero(m.Image) { // not required
-			return nil
-		}
-
 		if err := m.Image.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("image")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}

--- a/stackpath/api/workload/workload_models/v1_update_image_request.go
+++ b/stackpath/api/workload/workload_models/v1_update_image_request.go
@@ -45,8 +45,6 @@ func (m *V1UpdateImageRequest) validateImage(formats strfmt.Registry) error {
 		if err := m.Image.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("image")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -72,16 +70,9 @@ func (m *V1UpdateImageRequest) ContextValidate(ctx context.Context, formats strf
 func (m *V1UpdateImageRequest) contextValidateImage(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Image != nil {
-
-		if swag.IsZero(m.Image) { // not required
-			return nil
-		}
-
 		if err := m.Image.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("image")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}

--- a/stackpath/api/workload/workload_models/v1_update_image_response.go
+++ b/stackpath/api/workload/workload_models/v1_update_image_response.go
@@ -45,8 +45,6 @@ func (m *V1UpdateImageResponse) validateImage(formats strfmt.Registry) error {
 		if err := m.Image.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("image")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -72,16 +70,9 @@ func (m *V1UpdateImageResponse) ContextValidate(ctx context.Context, formats str
 func (m *V1UpdateImageResponse) contextValidateImage(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Image != nil {
-
-		if swag.IsZero(m.Image) { // not required
-			return nil
-		}
-
 		if err := m.Image.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("image")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}

--- a/stackpath/api/workload/workload_models/v1_update_workload_request.go
+++ b/stackpath/api/workload/workload_models/v1_update_workload_request.go
@@ -45,8 +45,6 @@ func (m *V1UpdateWorkloadRequest) validateWorkload(formats strfmt.Registry) erro
 		if err := m.Workload.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("workload")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -72,16 +70,9 @@ func (m *V1UpdateWorkloadRequest) ContextValidate(ctx context.Context, formats s
 func (m *V1UpdateWorkloadRequest) contextValidateWorkload(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Workload != nil {
-
-		if swag.IsZero(m.Workload) { // not required
-			return nil
-		}
-
 		if err := m.Workload.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("workload")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}

--- a/stackpath/api/workload/workload_models/v1_update_workload_response.go
+++ b/stackpath/api/workload/workload_models/v1_update_workload_response.go
@@ -45,8 +45,6 @@ func (m *V1UpdateWorkloadResponse) validateWorkload(formats strfmt.Registry) err
 		if err := m.Workload.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("workload")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -72,16 +70,9 @@ func (m *V1UpdateWorkloadResponse) ContextValidate(ctx context.Context, formats 
 func (m *V1UpdateWorkloadResponse) contextValidateWorkload(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Workload != nil {
-
-		if swag.IsZero(m.Workload) { // not required
-			return nil
-		}
-
 		if err := m.Workload.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("workload")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}

--- a/stackpath/api/workload/workload_models/v1_virtual_machine_spec.go
+++ b/stackpath/api/workload/workload_models/v1_virtual_machine_spec.go
@@ -82,8 +82,6 @@ func (m *V1VirtualMachineSpec) validateLivenessProbe(formats strfmt.Registry) er
 		if err := m.LivenessProbe.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("livenessProbe")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -101,8 +99,6 @@ func (m *V1VirtualMachineSpec) validatePorts(formats strfmt.Registry) error {
 		if err := m.Ports.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("ports")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -120,8 +116,6 @@ func (m *V1VirtualMachineSpec) validateReadinessProbe(formats strfmt.Registry) e
 		if err := m.ReadinessProbe.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("readinessProbe")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -139,8 +133,6 @@ func (m *V1VirtualMachineSpec) validateResources(formats strfmt.Registry) error 
 		if err := m.Resources.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("resources")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -163,8 +155,6 @@ func (m *V1VirtualMachineSpec) validateVolumeMounts(formats strfmt.Registry) err
 			if err := m.VolumeMounts[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("volumeMounts" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}
@@ -208,16 +198,9 @@ func (m *V1VirtualMachineSpec) ContextValidate(ctx context.Context, formats strf
 func (m *V1VirtualMachineSpec) contextValidateLivenessProbe(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.LivenessProbe != nil {
-
-		if swag.IsZero(m.LivenessProbe) { // not required
-			return nil
-		}
-
 		if err := m.LivenessProbe.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("livenessProbe")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -228,15 +211,9 @@ func (m *V1VirtualMachineSpec) contextValidateLivenessProbe(ctx context.Context,
 
 func (m *V1VirtualMachineSpec) contextValidatePorts(ctx context.Context, formats strfmt.Registry) error {
 
-	if swag.IsZero(m.Ports) { // not required
-		return nil
-	}
-
 	if err := m.Ports.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("ports")
-		} else if ce, ok := err.(*errors.CompositeError); ok {
-			return ce
 		}
 		return err
 	}
@@ -247,16 +224,9 @@ func (m *V1VirtualMachineSpec) contextValidatePorts(ctx context.Context, formats
 func (m *V1VirtualMachineSpec) contextValidateReadinessProbe(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.ReadinessProbe != nil {
-
-		if swag.IsZero(m.ReadinessProbe) { // not required
-			return nil
-		}
-
 		if err := m.ReadinessProbe.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("readinessProbe")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -268,16 +238,9 @@ func (m *V1VirtualMachineSpec) contextValidateReadinessProbe(ctx context.Context
 func (m *V1VirtualMachineSpec) contextValidateResources(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Resources != nil {
-
-		if swag.IsZero(m.Resources) { // not required
-			return nil
-		}
-
 		if err := m.Resources.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("resources")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -291,16 +254,9 @@ func (m *V1VirtualMachineSpec) contextValidateVolumeMounts(ctx context.Context, 
 	for i := 0; i < len(m.VolumeMounts); i++ {
 
 		if m.VolumeMounts[i] != nil {
-
-			if swag.IsZero(m.VolumeMounts[i]) { // not required
-				return nil
-			}
-
 			if err := m.VolumeMounts[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("volumeMounts" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}

--- a/stackpath/api/workload/workload_models/v1_virtual_machine_spec_map_entry.go
+++ b/stackpath/api/workload/workload_models/v1_virtual_machine_spec_map_entry.go
@@ -29,11 +29,6 @@ func (m V1VirtualMachineSpecMapEntry) Validate(formats strfmt.Registry) error {
 		}
 		if val, ok := m[k]; ok {
 			if err := val.Validate(formats); err != nil {
-				if ve, ok := err.(*errors.Validation); ok {
-					return ve.ValidateName(k)
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
-				}
 				return err
 			}
 		}

--- a/stackpath/api/workload/workload_models/v1_virtual_machine_status.go
+++ b/stackpath/api/workload/workload_models/v1_virtual_machine_status.go
@@ -54,8 +54,6 @@ func (m *V1VirtualMachineStatus) validatePhase(formats strfmt.Registry) error {
 		if err := m.Phase.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("phase")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -81,16 +79,9 @@ func (m *V1VirtualMachineStatus) ContextValidate(ctx context.Context, formats st
 func (m *V1VirtualMachineStatus) contextValidatePhase(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Phase != nil {
-
-		if swag.IsZero(m.Phase) { // not required
-			return nil
-		}
-
 		if err := m.Phase.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("phase")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}

--- a/stackpath/api/workload/workload_models/v1_volume_claim.go
+++ b/stackpath/api/workload/workload_models/v1_volume_claim.go
@@ -37,7 +37,7 @@ type V1VolumeClaim struct {
 
 	// A volume claim's programmatic name
 	//
-	// Volume claim slugs are used to programmatically label a claim
+	// Volume claim slugs are used to programatically label a claim
 	Slug string `json:"slug,omitempty"`
 
 	// spec
@@ -79,8 +79,6 @@ func (m *V1VolumeClaim) validateMetadata(formats strfmt.Registry) error {
 		if err := m.Metadata.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("metadata")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -98,8 +96,6 @@ func (m *V1VolumeClaim) validatePhase(formats strfmt.Registry) error {
 		if err := m.Phase.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("phase")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -117,8 +113,6 @@ func (m *V1VolumeClaim) validateSpec(formats strfmt.Registry) error {
 		if err := m.Spec.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("spec")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -169,16 +163,9 @@ func (m *V1VolumeClaim) contextValidateID(ctx context.Context, formats strfmt.Re
 func (m *V1VolumeClaim) contextValidateMetadata(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Metadata != nil {
-
-		if swag.IsZero(m.Metadata) { // not required
-			return nil
-		}
-
 		if err := m.Metadata.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("metadata")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -190,16 +177,9 @@ func (m *V1VolumeClaim) contextValidateMetadata(ctx context.Context, formats str
 func (m *V1VolumeClaim) contextValidatePhase(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Phase != nil {
-
-		if swag.IsZero(m.Phase) { // not required
-			return nil
-		}
-
 		if err := m.Phase.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("phase")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -211,16 +191,9 @@ func (m *V1VolumeClaim) contextValidatePhase(ctx context.Context, formats strfmt
 func (m *V1VolumeClaim) contextValidateSpec(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Spec != nil {
-
-		if swag.IsZero(m.Spec) { // not required
-			return nil
-		}
-
 		if err := m.Spec.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("spec")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}

--- a/stackpath/api/workload/workload_models/v1_volume_claim_spec.go
+++ b/stackpath/api/workload/workload_models/v1_volume_claim_spec.go
@@ -50,8 +50,6 @@ func (m *V1VolumeClaimSpec) validateResources(formats strfmt.Registry) error {
 		if err := m.Resources.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("resources")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -77,16 +75,9 @@ func (m *V1VolumeClaimSpec) ContextValidate(ctx context.Context, formats strfmt.
 func (m *V1VolumeClaimSpec) contextValidateResources(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Resources != nil {
-
-		if swag.IsZero(m.Resources) { // not required
-			return nil
-		}
-
 		if err := m.Resources.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("resources")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}

--- a/stackpath/api/workload/workload_models/v1_workload.go
+++ b/stackpath/api/workload/workload_models/v1_workload.go
@@ -86,8 +86,6 @@ func (m *V1Workload) validateMetadata(formats strfmt.Registry) error {
 		if err := m.Metadata.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("metadata")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -105,8 +103,6 @@ func (m *V1Workload) validateSpec(formats strfmt.Registry) error {
 		if err := m.Spec.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("spec")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -124,8 +120,6 @@ func (m *V1Workload) validateStatus(formats strfmt.Registry) error {
 		if err := m.Status.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("status")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -143,8 +137,6 @@ func (m *V1Workload) validateTargets(formats strfmt.Registry) error {
 		if err := m.Targets.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("targets")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -199,16 +191,9 @@ func (m *V1Workload) contextValidateID(ctx context.Context, formats strfmt.Regis
 func (m *V1Workload) contextValidateMetadata(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Metadata != nil {
-
-		if swag.IsZero(m.Metadata) { // not required
-			return nil
-		}
-
 		if err := m.Metadata.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("metadata")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -220,16 +205,9 @@ func (m *V1Workload) contextValidateMetadata(ctx context.Context, formats strfmt
 func (m *V1Workload) contextValidateSpec(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Spec != nil {
-
-		if swag.IsZero(m.Spec) { // not required
-			return nil
-		}
-
 		if err := m.Spec.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("spec")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -250,16 +228,9 @@ func (m *V1Workload) contextValidateStackID(ctx context.Context, formats strfmt.
 func (m *V1Workload) contextValidateStatus(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Status != nil {
-
-		if swag.IsZero(m.Status) { // not required
-			return nil
-		}
-
 		if err := m.Status.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("status")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -270,15 +241,9 @@ func (m *V1Workload) contextValidateStatus(ctx context.Context, formats strfmt.R
 
 func (m *V1Workload) contextValidateTargets(ctx context.Context, formats strfmt.Registry) error {
 
-	if swag.IsZero(m.Targets) { // not required
-		return nil
-	}
-
 	if err := m.Targets.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("targets")
-		} else if ce, ok := err.(*errors.CompositeError); ok {
-			return ce
 		}
 		return err
 	}

--- a/stackpath/api/workload/workload_models/v1_workload_instance_container_runtime_settings.go
+++ b/stackpath/api/workload/workload_models/v1_workload_instance_container_runtime_settings.go
@@ -66,8 +66,6 @@ func (m *V1WorkloadInstanceContainerRuntimeSettings) validateDNSConfig(formats s
 		if err := m.DNSConfig.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("dnsConfig")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -90,8 +88,6 @@ func (m *V1WorkloadInstanceContainerRuntimeSettings) validateHostAliases(formats
 			if err := m.HostAliases[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("hostAliases" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}
@@ -111,8 +107,6 @@ func (m *V1WorkloadInstanceContainerRuntimeSettings) validateSecurityContext(for
 		if err := m.SecurityContext.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("securityContext")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -146,16 +140,9 @@ func (m *V1WorkloadInstanceContainerRuntimeSettings) ContextValidate(ctx context
 func (m *V1WorkloadInstanceContainerRuntimeSettings) contextValidateDNSConfig(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.DNSConfig != nil {
-
-		if swag.IsZero(m.DNSConfig) { // not required
-			return nil
-		}
-
 		if err := m.DNSConfig.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("dnsConfig")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -169,16 +156,9 @@ func (m *V1WorkloadInstanceContainerRuntimeSettings) contextValidateHostAliases(
 	for i := 0; i < len(m.HostAliases); i++ {
 
 		if m.HostAliases[i] != nil {
-
-			if swag.IsZero(m.HostAliases[i]) { // not required
-				return nil
-			}
-
 			if err := m.HostAliases[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("hostAliases" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}
@@ -192,16 +172,9 @@ func (m *V1WorkloadInstanceContainerRuntimeSettings) contextValidateHostAliases(
 func (m *V1WorkloadInstanceContainerRuntimeSettings) contextValidateSecurityContext(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.SecurityContext != nil {
-
-		if swag.IsZero(m.SecurityContext) { // not required
-			return nil
-		}
-
 		if err := m.SecurityContext.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("securityContext")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}

--- a/stackpath/api/workload/workload_models/v1_workload_instance_runtime_settings.go
+++ b/stackpath/api/workload/workload_models/v1_workload_instance_runtime_settings.go
@@ -52,8 +52,6 @@ func (m *V1WorkloadInstanceRuntimeSettings) validateContainers(formats strfmt.Re
 		if err := m.Containers.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("containers")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -71,8 +69,6 @@ func (m *V1WorkloadInstanceRuntimeSettings) validateVirtualMachines(formats strf
 		if err := m.VirtualMachines.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("virtualMachines")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -102,16 +98,9 @@ func (m *V1WorkloadInstanceRuntimeSettings) ContextValidate(ctx context.Context,
 func (m *V1WorkloadInstanceRuntimeSettings) contextValidateContainers(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Containers != nil {
-
-		if swag.IsZero(m.Containers) { // not required
-			return nil
-		}
-
 		if err := m.Containers.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("containers")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -123,16 +112,9 @@ func (m *V1WorkloadInstanceRuntimeSettings) contextValidateContainers(ctx contex
 func (m *V1WorkloadInstanceRuntimeSettings) contextValidateVirtualMachines(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.VirtualMachines != nil {
-
-		if swag.IsZero(m.VirtualMachines) { // not required
-			return nil
-		}
-
 		if err := m.VirtualMachines.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("virtualMachines")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}

--- a/stackpath/api/workload/workload_models/v1_workload_instance_security_context.go
+++ b/stackpath/api/workload/workload_models/v1_workload_instance_security_context.go
@@ -63,8 +63,6 @@ func (m *V1WorkloadInstanceSecurityContext) validateSysctls(formats strfmt.Regis
 			if err := m.Sysctls[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("sysctls" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}
@@ -94,16 +92,9 @@ func (m *V1WorkloadInstanceSecurityContext) contextValidateSysctls(ctx context.C
 	for i := 0; i < len(m.Sysctls); i++ {
 
 		if m.Sysctls[i] != nil {
-
-			if swag.IsZero(m.Sysctls[i]) { // not required
-				return nil
-			}
-
 			if err := m.Sysctls[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("sysctls" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}

--- a/stackpath/api/workload/workload_models/v1_workload_instance_vm_runtime_settings.go
+++ b/stackpath/api/workload/workload_models/v1_workload_instance_vm_runtime_settings.go
@@ -53,8 +53,6 @@ func (m *V1WorkloadInstanceVMRuntimeSettings) validateDNSConfig(formats strfmt.R
 		if err := m.DNSConfig.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("dnsConfig")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -77,8 +75,6 @@ func (m *V1WorkloadInstanceVMRuntimeSettings) validateHostAliases(formats strfmt
 			if err := m.HostAliases[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("hostAliases" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}
@@ -110,16 +106,9 @@ func (m *V1WorkloadInstanceVMRuntimeSettings) ContextValidate(ctx context.Contex
 func (m *V1WorkloadInstanceVMRuntimeSettings) contextValidateDNSConfig(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.DNSConfig != nil {
-
-		if swag.IsZero(m.DNSConfig) { // not required
-			return nil
-		}
-
 		if err := m.DNSConfig.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("dnsConfig")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -133,16 +122,9 @@ func (m *V1WorkloadInstanceVMRuntimeSettings) contextValidateHostAliases(ctx con
 	for i := 0; i < len(m.HostAliases); i++ {
 
 		if m.HostAliases[i] != nil {
-
-			if swag.IsZero(m.HostAliases[i]) { // not required
-				return nil
-			}
-
 			if err := m.HostAliases[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("hostAliases" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}

--- a/stackpath/api/workload/workload_models/v1_workload_spec.go
+++ b/stackpath/api/workload/workload_models/v1_workload_spec.go
@@ -90,8 +90,6 @@ func (m *V1WorkloadSpec) validateContainers(formats strfmt.Registry) error {
 		if err := m.Containers.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("containers")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -108,8 +106,6 @@ func (m *V1WorkloadSpec) validateImagePullCredentials(formats strfmt.Registry) e
 	if err := m.ImagePullCredentials.Validate(formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("imagePullCredentials")
-		} else if ce, ok := err.(*errors.CompositeError); ok {
-			return ce
 		}
 		return err
 	}
@@ -126,8 +122,6 @@ func (m *V1WorkloadSpec) validateInitContainers(formats strfmt.Registry) error {
 		if err := m.InitContainers.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("initContainers")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -150,8 +144,6 @@ func (m *V1WorkloadSpec) validateNetworkInterfaces(formats strfmt.Registry) erro
 			if err := m.NetworkInterfaces[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("networkInterfaces" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}
@@ -171,8 +163,6 @@ func (m *V1WorkloadSpec) validateRuntime(formats strfmt.Registry) error {
 		if err := m.Runtime.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("runtime")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -190,8 +180,6 @@ func (m *V1WorkloadSpec) validateVirtualMachines(formats strfmt.Registry) error 
 		if err := m.VirtualMachines.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("virtualMachines")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -214,8 +202,6 @@ func (m *V1WorkloadSpec) validateVolumeClaimTemplates(formats strfmt.Registry) e
 			if err := m.VolumeClaimTemplates[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("volumeClaimTemplates" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}
@@ -266,15 +252,9 @@ func (m *V1WorkloadSpec) ContextValidate(ctx context.Context, formats strfmt.Reg
 
 func (m *V1WorkloadSpec) contextValidateContainers(ctx context.Context, formats strfmt.Registry) error {
 
-	if swag.IsZero(m.Containers) { // not required
-		return nil
-	}
-
 	if err := m.Containers.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("containers")
-		} else if ce, ok := err.(*errors.CompositeError); ok {
-			return ce
 		}
 		return err
 	}
@@ -287,8 +267,6 @@ func (m *V1WorkloadSpec) contextValidateImagePullCredentials(ctx context.Context
 	if err := m.ImagePullCredentials.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("imagePullCredentials")
-		} else if ce, ok := err.(*errors.CompositeError); ok {
-			return ce
 		}
 		return err
 	}
@@ -298,15 +276,9 @@ func (m *V1WorkloadSpec) contextValidateImagePullCredentials(ctx context.Context
 
 func (m *V1WorkloadSpec) contextValidateInitContainers(ctx context.Context, formats strfmt.Registry) error {
 
-	if swag.IsZero(m.InitContainers) { // not required
-		return nil
-	}
-
 	if err := m.InitContainers.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("initContainers")
-		} else if ce, ok := err.(*errors.CompositeError); ok {
-			return ce
 		}
 		return err
 	}
@@ -319,16 +291,9 @@ func (m *V1WorkloadSpec) contextValidateNetworkInterfaces(ctx context.Context, f
 	for i := 0; i < len(m.NetworkInterfaces); i++ {
 
 		if m.NetworkInterfaces[i] != nil {
-
-			if swag.IsZero(m.NetworkInterfaces[i]) { // not required
-				return nil
-			}
-
 			if err := m.NetworkInterfaces[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("networkInterfaces" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}
@@ -342,16 +307,9 @@ func (m *V1WorkloadSpec) contextValidateNetworkInterfaces(ctx context.Context, f
 func (m *V1WorkloadSpec) contextValidateRuntime(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Runtime != nil {
-
-		if swag.IsZero(m.Runtime) { // not required
-			return nil
-		}
-
 		if err := m.Runtime.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("runtime")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -362,15 +320,9 @@ func (m *V1WorkloadSpec) contextValidateRuntime(ctx context.Context, formats str
 
 func (m *V1WorkloadSpec) contextValidateVirtualMachines(ctx context.Context, formats strfmt.Registry) error {
 
-	if swag.IsZero(m.VirtualMachines) { // not required
-		return nil
-	}
-
 	if err := m.VirtualMachines.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("virtualMachines")
-		} else if ce, ok := err.(*errors.CompositeError); ok {
-			return ce
 		}
 		return err
 	}
@@ -383,16 +335,9 @@ func (m *V1WorkloadSpec) contextValidateVolumeClaimTemplates(ctx context.Context
 	for i := 0; i < len(m.VolumeClaimTemplates); i++ {
 
 		if m.VolumeClaimTemplates[i] != nil {
-
-			if swag.IsZero(m.VolumeClaimTemplates[i]) { // not required
-				return nil
-			}
-
 			if err := m.VolumeClaimTemplates[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("volumeClaimTemplates" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}

--- a/stackpath/api/workload/workload_models/v1_workload_status.go
+++ b/stackpath/api/workload/workload_models/v1_workload_status.go
@@ -25,12 +25,8 @@ import (
 type V1WorkloadStatus string
 
 func NewV1WorkloadStatus(value V1WorkloadStatus) *V1WorkloadStatus {
-	return &value
-}
-
-// Pointer returns a pointer to a freshly-allocated V1WorkloadStatus.
-func (m V1WorkloadStatus) Pointer() *V1WorkloadStatus {
-	return &m
+	v := value
+	return &v
 }
 
 const (

--- a/stackpath/api/workload/workload_models/v1_wrapped_image_pull_credentials.go
+++ b/stackpath/api/workload/workload_models/v1_wrapped_image_pull_credentials.go
@@ -32,8 +32,6 @@ func (m V1WrappedImagePullCredentials) Validate(formats strfmt.Registry) error {
 			if err := m[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName(strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}
@@ -54,16 +52,9 @@ func (m V1WrappedImagePullCredentials) ContextValidate(ctx context.Context, form
 	for i := 0; i < len(m); i++ {
 
 		if m[i] != nil {
-
-			if swag.IsZero(m[i]) { // not required
-				return nil
-			}
-
 			if err := m[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName(strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}

--- a/stackpath/api/workload/workload_models/virtual_machine_status_phase.go
+++ b/stackpath/api/workload/workload_models/virtual_machine_status_phase.go
@@ -20,12 +20,8 @@ import (
 type VirtualMachineStatusPhase string
 
 func NewVirtualMachineStatusPhase(value VirtualMachineStatusPhase) *VirtualMachineStatusPhase {
-	return &value
-}
-
-// Pointer returns a pointer to a freshly-allocated VirtualMachineStatusPhase.
-func (m VirtualMachineStatusPhase) Pointer() *VirtualMachineStatusPhase {
-	return &m
+	v := value
+	return &v
 }
 
 const (

--- a/stackpath/api/workload/workload_models/volume_claim_volume_claim_phase.go
+++ b/stackpath/api/workload/workload_models/volume_claim_volume_claim_phase.go
@@ -25,12 +25,8 @@ import (
 type VolumeClaimVolumeClaimPhase string
 
 func NewVolumeClaimVolumeClaimPhase(value VolumeClaimVolumeClaimPhase) *VolumeClaimVolumeClaimPhase {
-	return &value
-}
-
-// Pointer returns a pointer to a freshly-allocated VolumeClaimVolumeClaimPhase.
-func (m VolumeClaimVolumeClaimPhase) Pointer() *VolumeClaimVolumeClaimPhase {
-	return &m
+	v := value
+	return &v
 }
 
 const (

--- a/stackpath/api/workload/workload_models/workloadv1_instance.go
+++ b/stackpath/api/workload/workload_models/workloadv1_instance.go
@@ -66,7 +66,7 @@ type Workloadv1Instance struct {
 
 	// An instance's name
 	//
-	// Instance names are generated from their corresponding workload's slug, followed by a unique hash
+	// Instance names are generated from their corresponsing workload's slug, followed by a unique hash
 	Name string `json:"name,omitempty"`
 
 	// An instance's network interfaces
@@ -193,8 +193,6 @@ func (m *Workloadv1Instance) validateContainerStatuses(formats strfmt.Registry) 
 			if err := m.ContainerStatuses[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("containerStatuses" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}
@@ -214,8 +212,6 @@ func (m *Workloadv1Instance) validateContainers(formats strfmt.Registry) error {
 		if err := m.Containers.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("containers")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -262,8 +258,6 @@ func (m *Workloadv1Instance) validateInitContainerStatuses(formats strfmt.Regist
 			if err := m.InitContainerStatuses[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("initContainerStatuses" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}
@@ -283,8 +277,6 @@ func (m *Workloadv1Instance) validateInitContainers(formats strfmt.Registry) err
 		if err := m.InitContainers.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("initContainers")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -302,8 +294,6 @@ func (m *Workloadv1Instance) validateLocation(formats strfmt.Registry) error {
 		if err := m.Location.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("location")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -321,8 +311,6 @@ func (m *Workloadv1Instance) validateMetadata(formats strfmt.Registry) error {
 		if err := m.Metadata.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("metadata")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -345,8 +333,6 @@ func (m *Workloadv1Instance) validateNetworkInterfaces(formats strfmt.Registry) 
 			if err := m.NetworkInterfaces[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("networkInterfaces" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}
@@ -366,8 +352,6 @@ func (m *Workloadv1Instance) validatePhase(formats strfmt.Registry) error {
 		if err := m.Phase.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("phase")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -385,8 +369,6 @@ func (m *Workloadv1Instance) validateResources(formats strfmt.Registry) error {
 		if err := m.Resources.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("resources")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -404,8 +386,6 @@ func (m *Workloadv1Instance) validateRuntime(formats strfmt.Registry) error {
 		if err := m.Runtime.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("runtime")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -452,8 +432,6 @@ func (m *Workloadv1Instance) validateVirtualMachineStatuses(formats strfmt.Regis
 			if err := m.VirtualMachineStatuses[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("virtualMachineStatuses" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}
@@ -473,8 +451,6 @@ func (m *Workloadv1Instance) validateVirtualMachines(formats strfmt.Registry) er
 		if err := m.VirtualMachines.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("virtualMachines")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -546,16 +522,9 @@ func (m *Workloadv1Instance) contextValidateContainerStatuses(ctx context.Contex
 	for i := 0; i < len(m.ContainerStatuses); i++ {
 
 		if m.ContainerStatuses[i] != nil {
-
-			if swag.IsZero(m.ContainerStatuses[i]) { // not required
-				return nil
-			}
-
 			if err := m.ContainerStatuses[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("containerStatuses" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}
@@ -568,15 +537,9 @@ func (m *Workloadv1Instance) contextValidateContainerStatuses(ctx context.Contex
 
 func (m *Workloadv1Instance) contextValidateContainers(ctx context.Context, formats strfmt.Registry) error {
 
-	if swag.IsZero(m.Containers) { // not required
-		return nil
-	}
-
 	if err := m.Containers.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("containers")
-		} else if ce, ok := err.(*errors.CompositeError); ok {
-			return ce
 		}
 		return err
 	}
@@ -589,16 +552,9 @@ func (m *Workloadv1Instance) contextValidateInitContainerStatuses(ctx context.Co
 	for i := 0; i < len(m.InitContainerStatuses); i++ {
 
 		if m.InitContainerStatuses[i] != nil {
-
-			if swag.IsZero(m.InitContainerStatuses[i]) { // not required
-				return nil
-			}
-
 			if err := m.InitContainerStatuses[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("initContainerStatuses" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}
@@ -611,15 +567,9 @@ func (m *Workloadv1Instance) contextValidateInitContainerStatuses(ctx context.Co
 
 func (m *Workloadv1Instance) contextValidateInitContainers(ctx context.Context, formats strfmt.Registry) error {
 
-	if swag.IsZero(m.InitContainers) { // not required
-		return nil
-	}
-
 	if err := m.InitContainers.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("initContainers")
-		} else if ce, ok := err.(*errors.CompositeError); ok {
-			return ce
 		}
 		return err
 	}
@@ -630,16 +580,9 @@ func (m *Workloadv1Instance) contextValidateInitContainers(ctx context.Context, 
 func (m *Workloadv1Instance) contextValidateLocation(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Location != nil {
-
-		if swag.IsZero(m.Location) { // not required
-			return nil
-		}
-
 		if err := m.Location.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("location")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -651,16 +594,9 @@ func (m *Workloadv1Instance) contextValidateLocation(ctx context.Context, format
 func (m *Workloadv1Instance) contextValidateMetadata(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Metadata != nil {
-
-		if swag.IsZero(m.Metadata) { // not required
-			return nil
-		}
-
 		if err := m.Metadata.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("metadata")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -674,16 +610,9 @@ func (m *Workloadv1Instance) contextValidateNetworkInterfaces(ctx context.Contex
 	for i := 0; i < len(m.NetworkInterfaces); i++ {
 
 		if m.NetworkInterfaces[i] != nil {
-
-			if swag.IsZero(m.NetworkInterfaces[i]) { // not required
-				return nil
-			}
-
 			if err := m.NetworkInterfaces[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("networkInterfaces" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}
@@ -697,16 +626,9 @@ func (m *Workloadv1Instance) contextValidateNetworkInterfaces(ctx context.Contex
 func (m *Workloadv1Instance) contextValidatePhase(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Phase != nil {
-
-		if swag.IsZero(m.Phase) { // not required
-			return nil
-		}
-
 		if err := m.Phase.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("phase")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -718,16 +640,9 @@ func (m *Workloadv1Instance) contextValidatePhase(ctx context.Context, formats s
 func (m *Workloadv1Instance) contextValidateResources(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Resources != nil {
-
-		if swag.IsZero(m.Resources) { // not required
-			return nil
-		}
-
 		if err := m.Resources.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("resources")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -739,16 +654,9 @@ func (m *Workloadv1Instance) contextValidateResources(ctx context.Context, forma
 func (m *Workloadv1Instance) contextValidateRuntime(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Runtime != nil {
-
-		if swag.IsZero(m.Runtime) { // not required
-			return nil
-		}
-
 		if err := m.Runtime.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("runtime")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce
 			}
 			return err
 		}
@@ -762,16 +670,9 @@ func (m *Workloadv1Instance) contextValidateVirtualMachineStatuses(ctx context.C
 	for i := 0; i < len(m.VirtualMachineStatuses); i++ {
 
 		if m.VirtualMachineStatuses[i] != nil {
-
-			if swag.IsZero(m.VirtualMachineStatuses[i]) { // not required
-				return nil
-			}
-
 			if err := m.VirtualMachineStatuses[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("virtualMachineStatuses" + "." + strconv.Itoa(i))
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce
 				}
 				return err
 			}
@@ -784,15 +685,9 @@ func (m *Workloadv1Instance) contextValidateVirtualMachineStatuses(ctx context.C
 
 func (m *Workloadv1Instance) contextValidateVirtualMachines(ctx context.Context, formats strfmt.Registry) error {
 
-	if swag.IsZero(m.VirtualMachines) { // not required
-		return nil
-	}
-
 	if err := m.VirtualMachines.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("virtualMachines")
-		} else if ce, ok := err.(*errors.CompositeError); ok {
-			return ce
 		}
 		return err
 	}

--- a/stackpath/api/workload/workload_models/workloadv1_instance_instance_phase.go
+++ b/stackpath/api/workload/workload_models/workloadv1_instance_instance_phase.go
@@ -29,12 +29,8 @@ import (
 type Workloadv1InstanceInstancePhase string
 
 func NewWorkloadv1InstanceInstancePhase(value Workloadv1InstanceInstancePhase) *Workloadv1InstanceInstancePhase {
-	return &value
-}
-
-// Pointer returns a pointer to a freshly-allocated Workloadv1InstanceInstancePhase.
-func (m Workloadv1InstanceInstancePhase) Pointer() *Workloadv1InstanceInstancePhase {
-	return &m
+	v := value
+	return &v
 }
 
 const (


### PR DESCRIPTION
When I run "make generate" on latest master with go-swagger v0.27.0 version(which is recommended in README to use for client code generation), I am seeing all client/models files being updated to indent some comments in generated code and status/string methods being removed for resource struct types. I dont see any notable changes in generated code apart from above mentioned changes which can break things.

raising PR to keep this generated client code and models changes outside of actual network allocation changes to make review process easy.