### PR TITLE
update stackpath provider documentation to include allocation resources and workload spec changes

### DIFF
--- a/website/docs/r/compute_network_allocation.html.markdown
+++ b/website/docs/r/compute_network_allocation.html.markdown
@@ -54,7 +54,7 @@ resource "stackpath_compute_network_allocation" "my-compute-network-allocation-n
 * `name` - (Required) A human readable name.
 * `slug` - (Required) A programmatic name for the network allocation.
 * `labels` - (Optional) Key/value pairs of arbitrary label names and values that can be referenced as selectors.
-* `annotations` - (Optional) Key/value pairs that define StackPath-specific network allocation configuration.
+* `annotations` - (Optional) Key/value pairs that define StackPath-specific network allocation configuration. Currently `ipam.platform.stackpath.net/force-assign-requested-ips` annotation is used to force assign requested ips from assignment.
 * `allocation_class` - (Required) A IP allocation class to allocate IP from. Supported values are stackpath-edge/private and stackpath-edge/unicast.
 * `ip_family` - (Required) An IP Family of the IPs being allocated. One of the IPv4 or IPv6 can be provided.
 * `prefix_length` - (Required) A Prefix length of IP allocation. Currently only 32 and 128

--- a/website/docs/r/compute_network_allocation.html.markdown
+++ b/website/docs/r/compute_network_allocation.html.markdown
@@ -3,12 +3,12 @@ layout: "stackpath"
 page_title: "StackPath: stackpath_compute_network_allocation"
 sidebar_current: "docs-stackpath-resource-compute-network-allocation"
 description: |-
-  IP allocation required for network interfaces of StackPath computing workloads.
+  IP allocations are used to allocate an IP address for immediate or future use with an allocation claim.
 ---
 
 # stackpath\_compute\_network\_allocation
 
-IP allocation used to allocate IP to network interfaces of StackPath computing workloads.
+IP allocations are used to allocate an IP address for immediate or future use with an allocation claim.
 
 ## Example Usage
 
@@ -38,7 +38,7 @@ resource "stackpath_compute_network_allocation" "my-compute-network-allocation-n
   }
 
   selectors {
-    # Apply the selectos to a specific edge compute location
+    # Apply the selectors to a specific edge compute location
     key = "cityCode"
     # The operator is the operation that should be applied to the value of the
     # label. Only the "in" operator is supported.
@@ -56,11 +56,11 @@ resource "stackpath_compute_network_allocation" "my-compute-network-allocation-n
 * `labels` - (Optional) Key/value pairs of arbitrary label names and values that can be referenced as selectors.
 * `annotations` - (Optional) Key/value pairs that define StackPath-specific network allocation configuration.
 * `allocation_class` - (Required) A IP allocation class to allocate IP from. Supported values are stackpath-edge/private and stackpath-edge/unicast.
-* `ip_family` - (Required) A IP Family of the IPs being allocated. One of the IPv4 or IPv6 can be provided.
+* `ip_family` - (Required) An IP Family of the IPs being allocated. One of the IPv4 or IPv6 can be provided.
 * `prefix_length` - (Required) A Prefix length of IP allocation. Currently only 32 and 128
 prefix length values are supported for IPv4 and IPv6 respectively.
-* `reclaim_policy` - (Required) A reclaim policy to be used for IP allocation. only RETAIN action is supported in reclaim policy specified in allocation resources being created from API.
-* `selectors` - (Required) A edge location selector that the network allocation applies to. See [Selectors](#selectors) below for details.
+* `reclaim_policy` - (Required) A reclaim policy to be used for IP allocation. Only the RETAIN action is supported in reclaim policy specified in allocation resources being created from API.
+* `selectors` - (Required) An edge location selector that the network allocation applies to. See [Selectors](#selectors) below for details.
 
 ### Selectors
 

--- a/website/docs/r/compute_network_allocation.html.markdown
+++ b/website/docs/r/compute_network_allocation.html.markdown
@@ -1,0 +1,79 @@
+---
+layout: "stackpath"
+page_title: "StackPath: stackpath_compute_network_allocation"
+sidebar_current: "docs-stackpath-resource-compute-network-allocation"
+description: |-
+  IP allocation required for network interfaces of StackPath computing workloads.
+---
+
+# stackpath\_compute\_network\_allocation
+
+IP allocation used to allocate IP to network interfaces of StackPath computing workloads.
+
+## Example Usage
+
+```hcl
+# Allocation resource to be used to allocation IPv4 IP addresses.
+resource "stackpath_compute_network_allocation" "my-compute-network-allocation-name-reference" {
+  # A human friendly name
+  name = "My compute network allocation name reference"
+  # A DNS compatible label value that is unique to your stack. This value must
+  # be RFC 1123 compliant (only contain "a-z", "0-9", "-", ".").
+  slug = "my-compute-network-allocation-name-reference"
+
+  # allocation class name
+  # only stackpath-edge/private and stackpath-edge/unicast allocation classes are supported for now
+  allocation_class = "stackpath-edge/unicast"
+
+  # allocation IP family, either IPv4 or IPv6
+  ip_family = "IPv4"
+
+  # allocation prefix length
+  # 32 and 128 are the only values supported for IPv4 and IPv6 respectively for now
+  prefix_length = 32
+
+  # allocation reclaim policy, only RETAIN action is supported from API
+  reclaim_policy {
+    action = "RETAIN"
+  }
+
+  selectors {
+    # Apply the selectos to a specific edge compute location
+    key = "cityCode"
+    # The operator is the operation that should be applied to the value of the
+    # label. Only the "in" operator is supported.
+    operator = "in"
+    # The values that the label value should be compared to
+    values = ["DFW"]
+  }
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) A human readable name.
+* `slug` - (Required) A programmatic name for the network allocation.
+* `labels` - (Optional) Key/value pairs of arbitrary label names and values that can be referenced as selectors.
+* `annotations` - (Optional) Key/value pairs that define StackPath-specific network allocation configuration.
+* `allocation_class` - (Required) A IP allocation class to allocate IP from. Supported values are stackpath-edge/private and stackpath-edge/unicast.
+* `ip_family` - (Required) A IP Family of the IPs being allocated. One of the IPv4 or IPv6 can be provided.
+* `prefix_length` - (Required) A Prefix length of IP allocation. Currently only 32 and 128
+prefix length values are supported for IPv4 and IPv6 respectively.
+* `reclaim_policy` - (Required) A reclaim policy to be used for IP allocation. only RETAIN action is supported in reclaim policy specified in allocation resources being created from API.
+* `selectors` - (Required) A edge location selector that the network allocation applies to. See [Selectors](#selectors) below for details.
+
+### Selectors
+
+`selectors` take the following arguments:
+
+* `key` - (Required) The name of the data that a selector is based on.
+* `operator` - (Required) A logical operator to apply to a selector. Only the "in" operator is supported.
+* `values` - (Required) Data values to look for in a label selector.
+
+## Import
+
+StackPath compute network allocations can be imported by their stack-slug/allocation-slug formatted id. e.g.
+
+```bash
+$terraform import stackpath_compute_network_allocation.terraform bdb77768-2938-4ad8-a736-be5290add801/allocation-slug
+```

--- a/website/docs/r/compute_network_allocation.html.markdown
+++ b/website/docs/r/compute_network_allocation.html.markdown
@@ -54,7 +54,7 @@ resource "stackpath_compute_network_allocation" "my-compute-network-allocation-n
 * `name` - (Required) A human readable name.
 * `slug` - (Required) A programmatic name for the network allocation.
 * `labels` - (Optional) Key/value pairs of arbitrary label names and values that can be referenced as selectors.
-* `annotations` - (Optional) Key/value pairs that define StackPath-specific network allocation configuration. Currently `ipam.platform.stackpath.net/force-assign-requested-ips` annotation is used to force assign requested ips from assignment.
+* `annotations` - (Optional) Key/value pairs that define StackPath-specific network allocation configuration.
 * `allocation_class` - (Required) A IP allocation class to allocate IP from. Supported values are stackpath-edge/private and stackpath-edge/unicast.
 * `ip_family` - (Required) An IP Family of the IPs being allocated. One of the IPv4 or IPv6 can be provided.
 * `prefix_length` - (Required) A Prefix length of IP allocation. Currently only 32 and 128

--- a/website/docs/r/compute_network_allocation_claim.html.markdown
+++ b/website/docs/r/compute_network_allocation_claim.html.markdown
@@ -1,0 +1,196 @@
+---
+layout: "stackpath"
+page_title: "StackPath: stackpath_compute_network_allocation_claim"
+sidebar_current: "docs-stackpath-resource-compute-network-allocation-claim"
+description: |-
+  IP allocation claim required to claim IP from an allocation.
+---
+
+# stackpath\_compute\_network\_allocation\_claim
+
+IP allocation claim used to claim IP from an allocation to network interfaces of StackPath computing workloads.
+
+## Example Usage
+
+```hcl
+# Allocation claim resource using allocation.name spec to refer allocation and
+# claim IP from it.
+resource "stackpath_compute_network_allocation_claim" "allocation-claim-allocation-name-reference" {
+  # A human friendly name
+  name = "My allocation claim with name reference"
+  # A DNS compatible label value that is unique to your stack. This value must
+  # be RFC 1123 compliant (only contain "a-z", "0-9", "-", ".").
+  slug = "allocation-claim-allocation-name-reference"
+
+  # allocation IP family, either IPv4 or IPv6
+  ip_family = "IPv4"
+
+  # allocation prefix length
+  prefix_length = 32
+
+  # allocation reclaim policy, only RETAIN action is supported from API
+  reclaim_policy {
+    action = "RETAIN"
+  }
+
+  allocation {
+    # name of the allocation to claim IP from
+    # <replace stack slug with actual stack slug where resources are being created>
+    name = "<stack-slug>/my-compute-network-allocation-name-reference"
+  }
+}
+
+# Allocation claim resource using allocation.selector spec to refer allocation and
+# claim IP from it.
+resource "stackpath_compute_network_allocation_claim" "allocation-claim-allocation-selector" {
+  # A human friendly name
+  name = "My allocation claim with selector"
+  # A DNS compatible label value that is unique to your stack. This value must
+  # be RFC 1123 compliant (only contain "a-z", "0-9", "-", ".").
+  slug = "allocation-claim-allocation-selector"
+
+  # allocation IP family, either IPv4 or IPv6
+  ip_family = "IPv4"
+
+  # allocation prefix length
+  prefix_length = 32
+
+  # allocation reclaim policy, only RETAIN action is supported from API
+  reclaim_policy {
+    action = "RETAIN"
+  }
+
+  allocation {
+    # use selector to match to cityCode and allocation label to claim from.
+    selector {
+      allocation_class = "stackpath-edge/unicast"
+      match_expressions {
+        key = "cityCode"
+        operator = "in"
+        values = ["DFW"]
+      }
+
+      match_expressions {
+        key = "app"
+        operator = "in"
+        values = ["my-compute-network-allocation-selector"]
+      }
+    }
+  }
+
+  depends_on = [
+    stackpath_compute_network_allocation.my-compute-network-allocation-selector
+  ]
+}
+
+# Allocation claim resource using allocation.template spec to specify allocation
+# specification. allocation is created internally with provided template spec and then
+# used to claim IP from it.
+resource "stackpath_compute_network_allocation_claim" "allocation-claim-allocation-template" {
+  # A human friendly name
+  name = "My allocation claim with allocation template"
+  # A DNS compatible label value that is unique to your stack. This value must
+  # be RFC 1123 compliant (only contain "a-z", "0-9", "-", ".").
+  slug = "allocation-claim-allocation-template"
+
+  # allocation IP family, either IPv4 or IPv6
+  ip_family = "IPv4"
+
+  # allocation prefix length
+  prefix_length = 32
+
+  # allocation reclaim policy, only RETAIN action is supported from API
+  reclaim_policy {
+    action = "RETAIN"
+  }
+
+  allocation {
+    # use selector to match to cityCode and allocation label to claim from.
+    template {
+      allocation_class = "stackpath-edge/unicast"
+      ip_family = "IPv4"
+      prefix_length = 32
+      reclaim_policy {
+        action = "RETAIN"
+      }
+
+      selectors {
+        key = "cityCode"
+        operator = "in"
+        values = ["DFW"]
+      }
+    }
+  }
+}
+
+```
+
+## Argument Reference
+
+* `name` - (Required) A human readable name.
+* `slug` - (Required) A programmatic name for the network allocation claim.
+* `labels` - (Optional) Key/value pairs of arbitrary label names and values that can be referenced as selectors.
+* `annotations` - (Optional) Key/value pairs that define StackPath-specific network allocation configuration.
+* `ip_family` - (Required) A IP Family of the IPs being allocated. One of the IPv4 or IPv6 can be provided.
+* `prefix_length` - (Required) A Prefix length of IP allocation. Currently only 32 and 128
+prefix length values are supported for IPv4 and IPv6 respectively.
+* `reclaim_policy` - (Required) A reclaim policy to be used for IP allocation. only RETAIN action is supported in reclaim policy specified in allocation resources being created from API.
+* `allocation` - (Required) An allocation for the claim can be defined in three mutually exclusive ways:
+
+1. Directly via reference in resource name format.
+2. Selecting across a set of existing allocations, allowing for the definition of "pools" of addresses to use for different purposes.
+3. Via the definition of a `template`, which will create an allocation for the claim if one does not already exist. The allocation will be identified by a slug unique to the claim.
+
+See [Allocation](#allocation) below for details.
+
+### Allocation
+
+`allocation` take the one of the following arguments:
+
+* `name` - (Optional) The name of allocation in resource name format.
+* `selector` - (Required) A selector to select existing allocation using allocation_class
+and match_expressions used to match allocation. See [Selector](#selector) below for details.
+* `template` - (Required) A allocation resource template, it creates an allocation using
+provided template if allocation does not exist. See [Template](#template) below for details.
+
+### Selector
+
+`selector` takes following arguments:
+
+* `allocation_class` - (Required) A IP allocation class to allocate IP from. Supported values are stackpath-edge/private and stackpath-edge/unicast.
+* `match_expressions` - (Required) A list of match expressions to match allocation. See [Match_Expressions](#match_expressions) below for details
+
+### Match_Expressions
+
+`match_expressions` take the following arguments:
+
+* `key` - (Required) The name of the data that a selector is based on.
+* `operator` - (Required) A logical operator to apply to a selector. Only the "in" operator is supported.
+* `values` - (Required) Data values to look for in a label selector.
+
+### Template
+
+`template` take the following arguments:
+
+* `allocation_class` - (Required) A IP allocation class to allocate IP from. Supported values are stackpath-edge/private and stackpath-edge/unicast.
+* `ip_family` - (Required) A IP Family of the IPs being allocated. One of the IPv4 or IPv6 can be provided.
+* `prefix_length` - (Required) A Prefix length of IP allocation. Currently only 32 and 128
+prefix length values are supported for IPv4 and IPv6 respectively.
+* `reclaim_policy` - (Required) A reclaim policy to be used for IP allocation. only RETAIN action is supported in reclaim policy specified in allocation resources being created from API.
+* `selectors` - (Required) A edge location selector that the network allocation applies to. See [Selectors](#selectors) below for details.
+
+### Selectors
+
+`selectors` take the following arguments:
+
+* `key` - (Required) The name of the data that a selector is based on.
+* `operator` - (Required) A logical operator to apply to a selector. Only the "in" operator is supported.
+* `values` - (Required) Data values to look for in a label selector.
+
+## Import
+
+StackPath compute network allocation claims can be imported by their stack-slug/allocationclaim-slug formatted id. e.g.
+
+```bash
+$terraform import stackpath_compute_network_allocation.terraform bdb77768-2938-4ad8-a736-be5290add801/allocationclaim-slug
+```

--- a/website/docs/r/compute_network_allocation_claim.html.markdown
+++ b/website/docs/r/compute_network_allocation_claim.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # stackpath\_compute\_network\_allocation\_claim
 
-IP allocation claim used to claim IP from an allocation to network interfaces of StackPath computing workloads.
+IP allocation claim is used to claim an IP address from an allocation and bind it to a named resource such as a network interface of StackPath computing workloads.
 
 ## Example Usage
 
@@ -131,10 +131,10 @@ resource "stackpath_compute_network_allocation_claim" "allocation-claim-allocati
 * `slug` - (Required) A programmatic name for the network allocation claim.
 * `labels` - (Optional) Key/value pairs of arbitrary label names and values that can be referenced as selectors.
 * `annotations` - (Optional) Key/value pairs that define StackPath-specific network allocation configuration.
-* `ip_family` - (Required) A IP Family of the IPs being allocated. One of the IPv4 or IPv6 can be provided.
-* `prefix_length` - (Required) A Prefix length of IP allocation. Currently only 32 and 128
+* `ip_family` - (Required) An IP Family of the IPs being allocated. One of the IPv4 or IPv6 can be provided.
+* `prefix_length` - (Required) A prefix length of IP allocation. Currently only 32 and 128
 prefix length values are supported for IPv4 and IPv6 respectively.
-* `reclaim_policy` - (Required) A reclaim policy to be used for IP allocation. only RETAIN action is supported in reclaim policy specified in allocation resources being created from API.
+* `reclaim_policy` - (Required) A reclaim policy to be used for IP allocation. Only the RETAIN action is supported in reclaim policy specified in allocation resources being created from API.
 * `allocation` - (Required) An allocation for the claim can be defined in three mutually exclusive ways:
 
 1. Directly via reference in resource name format.
@@ -147,22 +147,21 @@ See [Allocation](#allocation) below for details.
 
 `allocation` take the one of the following arguments:
 
-* `name` - (Optional) The name of allocation in resource name format.
-* `selector` - (Required) A selector to select existing allocation using allocation_class
-and match_expressions used to match allocation. See [Selector](#selector) below for details.
-* `template` - (Required) A allocation resource template, it creates an allocation using
-provided template if allocation does not exist. See [Template](#template) below for details.
+* `name` - (Optional) The name of an allocation in resource name format.
+* `selector` - (Required) A selector to select an existing allocation using allocation_class
+and match_expressions used to match an allocation. See [Selector](#selector) below for details.
+* `template` - (Required) An allocation resource template which is used to create an allocation if allocation does not exist. See [Template](#template) below for details.
 
 ### Selector
 
 `selector` takes following arguments:
 
-* `allocation_class` - (Required) A IP allocation class to allocate IP from. Supported values are stackpath-edge/private and stackpath-edge/unicast.
+* `allocation_class` - (Required) An IP allocation class to allocate an IP address from. Supported values are stackpath-edge/private and stackpath-edge/unicast.
 * `match_expressions` - (Required) A list of match expressions to match allocation. See [Match_Expressions](#match_expressions) below for details
 
 ### Match_Expressions
 
-`match_expressions` take the following arguments:
+`match_expressions` values take the following arguments:
 
 * `key` - (Required) The name of the data that a selector is based on.
 * `operator` - (Required) A logical operator to apply to a selector. Only the "in" operator is supported.
@@ -172,16 +171,16 @@ provided template if allocation does not exist. See [Template](#template) below 
 
 `template` take the following arguments:
 
-* `allocation_class` - (Required) A IP allocation class to allocate IP from. Supported values are stackpath-edge/private and stackpath-edge/unicast.
-* `ip_family` - (Required) A IP Family of the IPs being allocated. One of the IPv4 or IPv6 can be provided.
-* `prefix_length` - (Required) A Prefix length of IP allocation. Currently only 32 and 128
+* `allocation_class` - (Required) An IP allocation class to allocate IP address from. Supported values are stackpath-edge/private and stackpath-edge/unicast.
+* `ip_family` - (Required) An IP Family of the IPs being allocated. One of IPv4 or IPv6 can be provided.
+* `prefix_length` - (Required) A prefix length of IP allocation. Currently only 32 and 128
 prefix length values are supported for IPv4 and IPv6 respectively.
-* `reclaim_policy` - (Required) A reclaim policy to be used for IP allocation. only RETAIN action is supported in reclaim policy specified in allocation resources being created from API.
-* `selectors` - (Required) A edge location selector that the network allocation applies to. See [Selectors](#selectors) below for details.
+* `reclaim_policy` - (Required) A reclaim policy to be used for IP allocation. Only RETAIN action is supported in reclaim policy specified in allocation resources being created from API.
+* `selectors` - (Required) An edge location selector that the network allocation applies to. See [Selectors](#selectors) below for details.
 
 ### Selectors
 
-`selectors` take the following arguments:
+`selectors` values take the following arguments:
 
 * `key` - (Required) The name of the data that a selector is based on.
 * `operator` - (Required) A logical operator to apply to a selector. Only the "in" operator is supported.

--- a/website/docs/r/compute_workload.html.markdown
+++ b/website/docs/r/compute_workload.html.markdown
@@ -165,17 +165,17 @@ nat to interface VPC IP address. Default is true.
 If Dual stack [IPv4, IPv6] is requested then VPC network specified in `network` field
 is expected to enabled for Dual stack networking. Bu default all Default networks are enabled for Dual stack, any user created VPC network needs to be created with [IPv4, IPv6] IPFamilies to enable it for Dual stack networking.
 * `assignments` - (Optional) A list of network assignments used to assign IPs to a network
-interface. If assignments are not provided explicitely then default network assignments
-are added to workload spec based on `ip_families` and `enable_one_to_one_nat` fields.
+interface. If assignments are not provided explicitly then default network assignments
+are added to the workload spec based on `ip_families` and `enable_one_to_one_nat` fields.
 See [Assignments](#assignments) below for details.
 
 ### Assignments
 
-Each assignment spec support the following arguments:
+Each assignment spec supports the following arguments:
 
 * `slug` - (Required) Unique identifier name for the assignment.
-* `mode` - (Required) Assignment mode representing allocation class from where IP allocation should happen. Currently supported assignment modes are PRIMARY, ONE_TO_ONE_NAT and FORWARD.
-* `allocation_claim_template` - (Required) Allocation claim template used to claim IPs from an allocation. more details about arguments required by allocation_claim_template can be found in [allocation claim](/docs/providers/stackpath/r/compute_network_allocation_claim.html).
+* `mode` - (Required) Assignment mode representing an allocation class from where IP allocation should happen. Currently supported assignment modes are PRIMARY, ONE_TO_ONE_NAT and FORWARD.
+* `allocation_claim_template` - (Required) Allocation claim template used to claim IPs from an allocation. More details about arguments required by allocation_claim_template can be found in [allocation claim](/docs/providers/stackpath/r/compute_network_allocation_claim.html).
 
 ### Image Pull Credentials
 

--- a/website/docs/r/compute_workload.html.markdown
+++ b/website/docs/r/compute_workload.html.markdown
@@ -164,6 +164,18 @@ nat to interface VPC IP address. Default is true.
 * `ip_families` - (Optional) List of IP Families from which IP allocation should happen to network interface. Default is [IPv4]. Currently this supports IPv4-only [IPv4] and Dual stack- [IPv4, IPv6]. It does not suport IPv6 only- [IPv6] requests.
 If Dual stack [IPv4, IPv6] is requested then VPC network specified in `network` field
 is expected to enabled for Dual stack networking. Bu default all Default networks are enabled for Dual stack, any user created VPC network needs to be created with [IPv4, IPv6] IPFamilies to enable it for Dual stack networking.
+* `assignments` - (Optional) A list of network assignments used to assign IPs to a network
+interface. If assignments are not provided explicitely then default network assignments
+are added to workload spec based on `ip_families` and `enable_one_to_one_nat` fields.
+See [Assignments](#assignments) below for details.
+
+### Assignments
+
+Each assignment spec support the following arguments:
+
+* `slug` - (Required) Unique identifier name for the assignment.
+* `mode` - (Required) Assignment mode representing allocation class from where IP allocation should happen. Currently supported assignment modes are PRIMARY, ONE_TO_ONE_NAT and FORWARD.
+* `allocation_claim_template` - (Required) Allocation claim template used to claim IPs from an allocation. more details about arguments required by allocation_claim_template can be found in [allocation claim](/docs/providers/stackpath/r/compute_network_allocation_claim.html).
 
 ### Image Pull Credentials
 


### PR DESCRIPTION
- Updated stackpath provider documentation to add newly supported resource `stackpath_compute_network_allocation` and `stackpath_compute_network_allocation_claim`.
- Updated existing documentation for workload to add documentation for network assignments in network interface.